### PR TITLE
Add support for Scala 2.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ which is available [as a gist](http://gist.github.com/246481) or [here](http://h
 Sonatype
 --------
 
-    libraryDependencies += "com.github.scopt" %% "scopt" % "2.0.0"
+    libraryDependencies += "com.github.scopt" %% "scopt" % "2.0.1"
 
 Usage
 -----

--- a/build.sbt
+++ b/build.sbt
@@ -10,16 +10,16 @@ licenses := Seq("MIT License" -> url("http://www.opensource.org/licenses/mit-lic
 
 description := """a command line options parsing library"""
 
-scalaVersion := "2.9.1"
+scalaVersion := "2.9.2"
 
-crossScalaVersions := Seq("2.9.1", "2.9.0-1", "2.8.1")
+crossScalaVersions := Seq("2.9.2", "2.9.1", "2.9.0-1", "2.8.1")
 
 // junit
 libraryDependencies += "junit" % "junit" % "4.7" % "test"
 
 // scalatest
 libraryDependencies <<= (scalaVersion, libraryDependencies) { (sv, deps) =>
-	val versionMap = Map("2.8.1" -> "1.5.1", "2.9.0-1" -> "1.6.1", "2.9.1" -> "1.6.1")
+	val versionMap = Map("2.8.1" -> "1.5.1", "2.9.0-1" -> "1.6.1", "2.9.1" -> "1.6.1", "2.9.2" -> "1.7.2")
 	val libName =
 	  if (List("2.8.1") contains sv) "scalatest_2.8.1" 
 	  else "scalatest_2.9.0"


### PR DESCRIPTION
Seems straight forward. Add the version, and make sure there is a corresponding ScalaTest version (1.7.2). Please push to maven repo. Thanks!
