### PR TITLE
Move to Scala 2.10.0-RC2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,9 +10,9 @@ licenses := Seq("MIT License" -> url("http://www.opensource.org/licenses/mit-lic
 
 description := """a command line options parsing library"""
 
-scalaVersion := "2.10.0-RC1"
+scalaVersion := "2.10.0-RC2"
 
-crossScalaVersions := Seq("2.10.0-RC1", "2.9.2", "2.9.1", "2.9.0-1", "2.8.1", "2.8.2")
+crossScalaVersions := Seq("2.10.0-RC2", "2.9.2", "2.9.1", "2.9.0-1", "2.8.1", "2.8.2")
 
 crossVersion <<= scalaVersion { sv =>
   ("-(M|RC)".r findFirstIn sv) map {_ => CrossVersion.full} getOrElse CrossVersion.binary


### PR DESCRIPTION
Hi, can you please push a RC2 build to sonatype?

Unfortunately I can't compile:

```
[info] Loading project definition from /Users/hhrutz/Documents/devel/scopt/project/project
Cloning into /Users/hhrutz/.sbt/staging/79327a3d91c5e99acc32...
...
[info] Compiling 1 Scala source to /Users/hhrutz/.sbt/staging/79327a3d91c5e99acc32/project/target/scala-2.9.2/sbt-0.12/classes...
fatal: remote error: 
  Repository not found.
Cloning into /Users/hhrutz/.sbt/staging/c5f2dec02fb1cc268736...
[error] Nonzero exit code (128): git clone git://github.com/sbt/sbt-site-plugin.git /Users/hhrutz/.sbt/staging/c5f2dec02fb1cc268736
[error] Use 'last' for the full log.
```

I don't know what this is doing. I have to remove `~/.sbt/staging` after running this.

Thanks!
