### PR TITLE
Changed the repository url of sbt-site-plugin.

### DIFF
--- a/project/project/Build.scala
+++ b/project/project/Build.scala
@@ -3,5 +3,5 @@ object PluginDef extends Build {
   override def projects = Seq(root)
   lazy val root = Project("plugins", file(".")) dependsOn(ghpages, site)
   lazy val ghpages = uri("git://github.com/jsuereth/xsbt-ghpages-plugin.git#1e7611")
-  lazy val site = uri("git://github.com/sbt/sbt-site-plugin.git#268967")
+  lazy val site = uri("git://github.com/sbt/sbt-site.git#268967")
 }


### PR DESCRIPTION
The repository of sbt-site-plugin is now git://github.com/sbt/sbt-site-plugin.git
