### PR TITLE
 option supports `hidden()' to hide it in any usage text

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Either case, first you need a case class that represents the configuration:
 ```scala
 import java.io.File
 case class Config(foo: Int = -1, out: File = new File("."), xyz: Boolean = false,
-  libName: String = "", maxCount: Int = -1, verbose: Boolean = false,
+  libName: String = "", maxCount: Int = -1, verbose: Boolean = false, debug: Boolean = false,
   mode: String = "", files: Seq[File] = Seq())
 ```
 
@@ -45,6 +45,8 @@ val parser = new scopt.OptionParser[Config]("scopt") {
   } keyValueName("<libname>", "<max>") text("maximum count for <libname>")
   opt[Unit]("verbose") action { (_, c) =>
     c.copy(verbose = true) } text("verbose is a flag")
+  opt[Unit]("debug") hidden() action { (_, c) =>
+    c.copy(debug = true) } text("this option is hidden in any usage text")
   note("some notes.\n")
   help("help") text("prints this usage text")
   arg[File]("<file>...") unbounded() optional() action { (x, c) =>
@@ -204,6 +206,8 @@ val parser = new scopt.OptionParser[Unit]("scopt") {
   } keyValueName("<libname>", "<max>") text("maximum count for <libname>")
   opt[Unit]("verbose") foreach { _ =>
     c = c.copy(verbose = true) } text("verbose is a flag")
+  opt[Unit]("debug") hidden() foreach { _ =>
+    c = c.copy(debug = true) } text("this option is hidden in any usage text")
   note("some notes.\n")
   help("help") text("prints this usage text")
   arg[java.io.File]("<file>...") unbounded() optional() foreach { x =>

--- a/src/test/scala/scopt/ImmutableParserSpec.scala
+++ b/src/test/scala/scopt/ImmutableParserSpec.scala
@@ -110,6 +110,8 @@ class ImmutableParserSpec extends Specification { def is =      s2"""
     print usage text                                            ${showUsageParser()}
                                                                 """
 
+  import SpecUtil._
+
   val unitParser1 = new scopt.OptionParser[Config]("scopt") {
     head("scopt", "3.x")
     opt[Unit]('f', "foo") action { (x, c) => c.copy(flag = true) }
@@ -362,7 +364,7 @@ class ImmutableParserSpec extends Specification { def is =      s2"""
       help("help") text("prints this usage text")
       arg[File]("<file>...") unbounded() optional() action { (x, c) =>
         c.copy(files = c.files :+ x) } text("optional unbounded args")
-      note("some notes.\n")
+      note("some notes.".newline)
       cmd("update") action { (_, c) =>
         c.copy(mode = "update") } text("update is a command.") children(
         opt[Unit]("not-keepalive") abbr("nk") action { (_, c) =>
@@ -394,7 +396,7 @@ update is a command.
   -nk | --not-keepalive
         disable keepalive
   --xyz <value>
-        xyz is a boolean property"""
+        xyz is a boolean property""".newlines
     val expectedHeader = """scopt 3.x"""
 
     (parser.header === expectedHeader) and (parser.usage === expectedUsage)
@@ -410,13 +412,13 @@ update is a command.
     bos.toString("UTF-8")
   }
   def reportErrorParser(msg: String) = {
-    printParser(_.reportError(msg)) === "Error: foo\n"
+    printParser(_.reportError(msg)) === "Error: foo".newline
   }
   def reportWarningParser(msg: String) = {
-    printParser(_.reportWarning(msg)) === "Warning: foo\n"
+    printParser(_.reportWarning(msg)) === "Warning: foo".newline
   }
   def showHeaderParser() = {
-    printParser(_.showHeader) === "scopt 3.x\n"
+    printParser(_.showHeader) === "scopt 3.x".newline
   }
   def showUsageParser() = {
     printParser(_.showUsage) === """scopt 3.x

--- a/src/test/scala/scopt/MutableParserSpec.scala
+++ b/src/test/scala/scopt/MutableParserSpec.scala
@@ -42,6 +42,9 @@ class MutableParserSpec extends Specification { def is =      s2"""
   opt[String]("foo") required() foreach { x => x } should
     fail to parse Nil                                           ${requiredFail()}
 
+  opt[Unit]("debug") hidden() foreach { x => x } should
+    parse () out of --debug                                     ${unitParserHidden("--debug")}
+
   unknown options should
     fail to parse by default                                    ${intParserFail("-z", "bar")}
 
@@ -89,6 +92,16 @@ class MutableParserSpec extends Specification { def is =      s2"""
     }
     val result = parser.parse(args.toSeq)
     (result === true) and (foo === true)
+  }
+
+  def unitParserHidden(args: String*) = {
+    var debug = false
+    val parser = new scopt.OptionParser[Unit]("scopt") {
+      head("scopt", "3.x")
+      opt[Unit]("debug") hidden() foreach { _ => debug = true }
+    }
+    val result = parser.parse(args.toSeq)
+    debug === true
   }
 
   def intParser(args: String*) = {
@@ -271,7 +284,7 @@ class MutableParserSpec extends Specification { def is =      s2"""
 
   def helpParser(args: String*) = {
     case class Config(foo: Int = -1, out: File = new File("."), xyz: Boolean = false,
-      libName: String = "", maxCount: Int = -1, verbose: Boolean = false,
+      libName: String = "", maxCount: Int = -1, verbose: Boolean = false, debug: Boolean = false,
       mode: String = "", files: Seq[File] = Seq(), keepalive: Boolean = false)
     var c = Config()    
     val parser = new scopt.OptionParser[Unit]("scopt") {
@@ -286,6 +299,8 @@ class MutableParserSpec extends Specification { def is =      s2"""
       } keyValueName("<libname>", "<max>") text("maximum count for <libname>")
       opt[Unit]("verbose") foreach { _ =>
         c = c.copy(verbose = true) } text("verbose is a flag")
+      opt[Unit]("debug") hidden() foreach { _ =>
+        c = c.copy(debug = true) } text("this option is hidden in any usage text")
       help("help") text("prints this usage text")
       arg[File]("<file>...") unbounded() optional() foreach { x =>
         c = c.copy(files = c.files :+ x) } text("optional unbounded args")
@@ -295,7 +310,9 @@ class MutableParserSpec extends Specification { def is =      s2"""
         opt[Unit]("not-keepalive") abbr("nk") foreach { _ =>
           c.copy(keepalive = false) } text("disable keepalive"),
         opt[Boolean]("xyz") foreach { x =>
-          c = c.copy(xyz = x) } text("xyz is a boolean property")
+          c = c.copy(xyz = x) } text("xyz is a boolean property"),
+        opt[Unit]("debug-update") hidden() foreach { _ =>
+          c = c.copy(debug = true) } text("this option is hidden in any usage text")
       )
     }
     parser.parse(args.toSeq)

--- a/src/test/scala/scopt/MutableParserSpec.scala
+++ b/src/test/scala/scopt/MutableParserSpec.scala
@@ -79,6 +79,8 @@ class MutableParserSpec extends Specification { def is =      s2"""
     print usage text                                            ${showUsageParser()}
                                                                 """
 
+  import SpecUtil._
+
   def unitParser(args: String*) = {
     var foo = false
     val parser = new scopt.OptionParser[Unit]("scopt") {
@@ -287,7 +289,7 @@ class MutableParserSpec extends Specification { def is =      s2"""
       help("help") text("prints this usage text")
       arg[File]("<file>...") unbounded() optional() foreach { x =>
         c = c.copy(files = c.files :+ x) } text("optional unbounded args")
-      note("some notes.\n")
+      note("some notes.".newline)
       cmd("update") foreach { _ =>
         c.copy(mode = "update") } text("update is a command.") children(
         opt[Unit]("not-keepalive") abbr("nk") foreach { _ =>
@@ -332,13 +334,13 @@ update is a command.
     bos.toString("UTF-8")
   }
   def reportErrorParser(msg: String) = {
-    printParser(_.reportError(msg)) === "Error: foo\n"
+    printParser(_.reportError(msg)) === "Error: foo".newline
   }
   def reportWarningParser(msg: String) = {
-    printParser(_.reportWarning(msg)) === "Warning: foo\n"
+    printParser(_.reportWarning(msg)) === "Warning: foo".newline
   }
   def showHeaderParser() = {
-    printParser(_.showHeader) === "scopt 3.x\n"
+    printParser(_.showHeader) === "scopt 3.x".newline
   }
   def showUsageParser() = {
     printParser(_.showUsage) === """scopt 3.x

--- a/src/test/scala/scopt/SpecUtil.scala
+++ b/src/test/scala/scopt/SpecUtil.scala
@@ -1,0 +1,8 @@
+
+object SpecUtil {
+  val envLineSeparator = util.Properties.lineSeparator
+  implicit class RichString(self: String) {
+    def newline: String = self + envLineSeparator
+    def newlines: String = self.lines.mkString(envLineSeparator)
+  }
+}


### PR DESCRIPTION
for advanced and/or inhibit option e.g. --debug, --unsafe
