### PR TITLE
Extended `termination()` function to pass through exit code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,11 +241,11 @@ cmd("backend") text("commands to manipulate backends:\n") action { (x, c) =>
 
 ### Termination Handling
 
-By default, when the `help` or `version` are invoked, they call `sys.exit` after printing the help or version information. If this is not desired (e.g. testing purposes), you can override the `terminate()` method:
+By default, when the `help` or `version` are invoked, they call `sys.exit(0)` after printing the help or version information. If this is not desired (e.g. testing purposes), you can override the `terminate(Int)` method:
 
 ```scala
 // Overriding the termination handler to no-op.
-override def terminate() = () => ()
+override def terminate(errorCode: Int) = ()
 ```
 
 ### Mutable parsing

--- a/src/main/scala/scopt/options.scala
+++ b/src/main/scala/scopt/options.scala
@@ -161,7 +161,7 @@ abstract case class OptionParser[C](programName: String) {
 
   def errorOnUnknownArgument: Boolean = true
   def showUsageOnError: Boolean = helpOptions.isEmpty
-  def terminate(): Unit = sys.exit
+  def terminate(exitCode: Int): Unit = sys.exit(exitCode)
 
   def reportError(msg: String): Unit = {
     Console.err.println("Error: " + msg)
@@ -213,7 +213,7 @@ abstract case class OptionParser[C](programName: String) {
   def help(name: String): OptionDef[Unit, C] = {
     val o = opt[Unit](name) action { (x, c) =>
       showUsage()
-      terminate()
+      terminate(0)
       c
     }
     helpOptions += o
@@ -227,7 +227,7 @@ abstract case class OptionParser[C](programName: String) {
   def version(name: String): OptionDef[Unit, C] =
     opt[Unit](name) action { (x, c) =>
       showHeader()
-      terminate()
+      terminate(0)
       c
     }
 

--- a/src/test/scala/scopt/ImmutableParserSpec.scala
+++ b/src/test/scala/scopt/ImmutableParserSpec.scala
@@ -1,5 +1,5 @@
 import java.security.{AccessControlException, Permission}
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+import java.util.concurrent.atomic.{AtomicInteger, AtomicBoolean, AtomicReference}
 
 import org.specs2._
 import java.util.{Calendar, GregorianCalendar}
@@ -516,8 +516,8 @@ update is a command.
     help("help") text("prints this usage text")
   }
 
-  lazy val terminationSafeParser1 = new scopt.OptionParser[Config]("scopt") {
-    override def terminate() = () ⇒ ()
+  def terminationSafeParser1(exitCode: AtomicInteger) = new scopt.OptionParser[Config]("scopt") {
+    override def terminate(ec: Int) = exitCode.set(ec)
     version("version")
     opt[Unit]("debug") action { (x, c) => c.copy(debug = true) }
     help("help") text("prints this usage text")
@@ -525,8 +525,10 @@ update is a command.
 
   def terminationSafeParser(args: String*) = {
     val exitWasCalled = new AtomicBoolean(false)
+    val exitCode = new AtomicInteger(-1)
     val sec = System.getSecurityManager
 
+    // We create a custom security manager for the purposes of determining whether `System.exit` was called
     val exitInhibitor = new SecurityManager() {
       override def checkExit(status: Int): Unit = {
         exitWasCalled.set(true)
@@ -545,12 +547,14 @@ update is a command.
 
     System.setSecurityManager(exitInhibitor)
 
-    val result = terminationSafeParser1.parse(args.toSeq, Config())
+    val parser = terminationSafeParser1(exitCode)
+
+    val result = parser.parse(args.toSeq, Config())
 
     // Reset to previous.
     System.setSecurityManager(sec)
 
-    result.isDefined && !exitWasCalled.get()
+    result.isDefined && !exitWasCalled.get() && exitCode.get() == 0
   }
 
   def printParserError(body: scopt.OptionParser[Config] => Unit): String = {


### PR DESCRIPTION
Strawman implementation for discussion in issue #73. Went for termination code pass through approach rather than anticipating use cases with some other abstraction.
