### PR TITLE
Added support for scala.concurrent.duration.Duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Command line options are defined using `opt[A]('f', "foo")` or `opt[A]("foo")` w
 - `Int`, `Long`, `Double`, `String`, `BigInt`, `BigDecimal`, `java.io.File`, `java.net.URI`, and `java.net.InetAddress` accept a value like `--foo 80` or `--foo:80`
 - `Boolean` accepts a value like `--foo true` or `--foo:1`
 - `java.util.Calendar` accepts a value like `--foo 2000-12-01`
+- `scala.concurrent.duration.Duration` accepts a value like `--foo 30s`
 - A pair of types like `(String, Int)` accept a key-value like `--foo:k=1` or `-f k=1`
 - A `Seq[File]` accepts a string containing comma-separated values such as `--jars foo.jar,bar.jar`
 - A `Map[String, String]` accepts a string containing comma-separated pairs like `--kwargs key1=val1,key2=val2`

--- a/src/main/scala/scopt/options.scala
+++ b/src/main/scala/scopt/options.scala
@@ -19,6 +19,7 @@ object Read {
   import java.io.File
   import java.net.URI
   import java.net.InetAddress
+  import scala.concurrent.duration.Duration
   def reads[A](f: String => A): Read[A] = new Read[A] {
     val arity = 1
     val reads = f
@@ -52,6 +53,7 @@ object Read {
   implicit val fileRead: Read[File]           = reads { new File(_) }
   implicit val uriRead: Read[URI]             = reads { new URI(_) }
   implicit val inetAddress: Read[InetAddress] = reads { InetAddress.getByName(_) }
+  implicit val durationRead: Read[Duration]   = reads { Duration(_) }
 
   implicit def tupleRead[A1: Read, A2: Read]: Read[(A1, A2)] = new Read[(A1, A2)] {
     val arity = 2


### PR DESCRIPTION
This PR adds support for `scala.concurrent.duration.Duration`. 

One thing worth to mention here is Duration throws NumberFormatException on unparsable input and the same exception is thrown for all numeric parsers. Thus it could be unclear what's wrong from the message ("... expects a number but was given '...'"). I thought I could just catch this exception in the reads itself and rethrow something else but this looks a bit ugly to me so it would be good to get some opinion on how to fix this right.

Thanks!
