### PR TITLE
Two-column rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 project/boot
 lib_managed
 *.i??
+.idea/

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ lazy val root = (project in file(".")).
         case _ => Nil
       }
     },
+    scalacOptions ++= Seq("-language:existentials"),
     resolvers += "sonatype-public" at "https://oss.sonatype.org/content/repositories/public",
     // scaladoc fix
     unmanagedClasspath in Compile += Attributed.blank(new java.io.File("doesnotexist"))

--- a/src/main/scala/scopt/options.scala
+++ b/src/main/scala/scopt/options.scala
@@ -178,7 +178,7 @@ abstract case class OptionParser[C](programName: String) {
 
   def errorOnUnknownArgument: Boolean = true
   def showUsageOnError: Boolean = helpOptions.isEmpty
-  def showCompactUsage: Boolean = false
+  def showTwoColumnUsage: Boolean = false
   def terminate(exitState: Either[String, Unit]): Unit =
     exitState match {
       case Left(_)  => sys.exit(1)
@@ -286,9 +286,9 @@ abstract case class OptionParser[C](programName: String) {
         xs.insertAll((xs indexOf x) + 1, cs)
       }
     }
-    val descriptions = if (showCompactUsage) {
-      val descCol = math.min(compactDescMaxCol, (xs map{_.usageNoDesc.length + WW.length}).max)
-      xs map {_.usageCompact(descCol)}
+    val descriptions = if (showTwoColumnUsage) {
+      val col1Len = math.min(column1MaxLength, (xs map {_.usageColumn1.length + WW.length}).max)
+      xs map {_.usageTwoColumn(col1Len)}
     } else xs map {_.usage}
     (if (header == "") "" else header + NL) +
     "Usage: " + commandExample(None) + NLNL +
@@ -643,19 +643,19 @@ class OptionDef[A: Read, C](
         WW + (_shortOpt map { o => "-" + o + " | " } getOrElse { "" }) +
         fullName + NLTB + _desc
     }
-  private[scopt] def usageCompact(descCol: Int): String = {
-    def spaceToDesc(str: String) = if (str.length <= descCol) str + " " * (descCol - str.length)
-                                   else str.dropRight(WW.length) + NL + " " * descCol
+  private[scopt] def usageTwoColumn(col1Length: Int): String = {
+    def spaceToDesc(str: String) = if (str.length <= col1Length) str + " " * (col1Length - str.length)
+                                   else str.dropRight(WW.length) + NL + " " * col1Length
     kind match {
       case Head | Note | Check => _desc
-      case Cmd => usageNoDesc + _desc
-      case Arg => spaceToDesc(usageNoDesc + WW) + _desc
-      case Opt if read.arity == 2 => spaceToDesc(usageNoDesc + WW) + _desc
-      case Opt if read.arity == 1 => spaceToDesc(usageNoDesc + WW) + _desc
-      case Opt => spaceToDesc(usageNoDesc + WW) + _desc
+      case Cmd => usageColumn1 + _desc
+      case Arg => spaceToDesc(usageColumn1 + WW) + _desc
+      case Opt if read.arity == 2 => spaceToDesc(usageColumn1 + WW) + _desc
+      case Opt if read.arity == 1 => spaceToDesc(usageColumn1 + WW) + _desc
+      case Opt => spaceToDesc(usageColumn1 + WW) + _desc
     }
   }
-  private[scopt] def usageNoDesc: String =
+  private[scopt] def usageColumn1: String =
     kind match {
       case Head | Note | Check => ""
       case Cmd =>
@@ -698,7 +698,7 @@ private[scopt] object OptionDef {
   val TB = "        "
   val NLTB = NL + TB
   val NLNL = NL + NL
-  val compactDescMaxCol = 28
+  val column1MaxLength = 25 + WW.length
   val defaultKeyName = "<key>"
   val defaultValueName = "<value>"
   val atomic = new java.util.concurrent.atomic.AtomicInteger

--- a/src/test/scala/scopt/ImmutableParserSpec.scala
+++ b/src/test/scala/scopt/ImmutableParserSpec.scala
@@ -584,7 +584,7 @@ update is a command.
       mode: String = "", files: Seq[File] = Seq(), keepalive: Boolean = false,
       jars: Seq[File] = Seq(), kwargs: Map[String,String] = Map())
     val parser = new scopt.OptionParser[Config]("scopt") {
-      override def showCompactUsage = true
+      override def showTwoColumnUsage = true
       head("scopt", "3.x")
       opt[Int]('f', "foo") action { (x, c) =>
         c.copy(foo = x) } text("foo is an integer property")
@@ -622,21 +622,21 @@ update is a command.
     val expectedUsage= """scopt 3.x
 Usage: scopt [update] [options] [<file>...]
 
-  -f, --foo <value>         foo is an integer property
-  -o, --out <file>          out is a required file property
-  --max:<libname>=<max>     maximum count for <libname>
+  -f, --foo <value>        foo is an integer property
+  -o, --out <file>         out is a required file property
+  --max:<libname>=<max>    maximum count for <libname>
   -j, --jars <jar1>,<jar2>...
-                            jars to include
-  --kwargs k1=v1,k2=v2...   other arguments
-  --verbose                 verbose is a flag
-  --help                    prints this usage text
-  <file>...                 optional unbounded args
+                           jars to include
+  --kwargs k1=v1,k2=v2...  other arguments
+  --verbose                verbose is a flag
+  --help                   prints this usage text
+  <file>...                optional unbounded args
 some notes.
 
 Command: update [options]
 update is a command.
-  -nk, --not-keepalive      disable keepalive
-  --xyz <value>             xyz is a boolean property""".newlines
+  -nk, --not-keepalive     disable keepalive
+  --xyz <value>            xyz is a boolean property""".newlines
     val expectedHeader = """scopt 3.x"""
 
     (parser.header === expectedHeader) and (parser.usage === expectedUsage)

--- a/src/test/scala/scopt/ImmutableParserSpec.scala
+++ b/src/test/scala/scopt/ImmutableParserSpec.scala
@@ -144,11 +144,11 @@ class ImmutableParserSpec extends Specification { def is = args(sequential = tru
     parse foo out of backend update foo                         ${nestedCmdParser("backend", "update", "foo")}
     fail to paser backend foo                                   ${nestedCmdParserFail("backend", "foo")}
 
-  help("help") should
-    print usage text --help                                     ${helpParser()}
+  help("help") if OneColumn should
+    print usage text --help                                     ${helpParserOneColumn()}
 
-  help("help") if compact should
-    print usage text --help                                     ${helpParserCompact()}
+  help("help") if TwoColumns should
+    print usage text --help                                     ${helpParserTwoColumns()}
 
   reportError("foo") should
     print "Error: foo\n"                                        ${reportErrorParser("foo")}
@@ -506,12 +506,13 @@ class ImmutableParserSpec extends Specification { def is = args(sequential = tru
     result === None
   }
 
-  def helpParser(args: String*) = {
+  def helpParserOneColumn(args: String*) = {
     case class Config(foo: Int = -1, out: File = new File("."), xyz: Boolean = false,
       libName: String = "", maxCount: Int = -1, verbose: Boolean = false, debug: Boolean = false,
       mode: String = "", files: Seq[File] = Seq(), keepalive: Boolean = false,
       jars: Seq[File] = Seq(), kwargs: Map[String,String] = Map())
     val parser = new scopt.OptionParser[Config]("scopt") {
+      override def renderingMode = scopt.RenderingMode.OneColumn
       head("scopt", "3.x")
       opt[Int]('f', "foo") action { (x, c) =>
         c.copy(foo = x) } text("foo is an integer property")
@@ -578,13 +579,12 @@ update is a command.
     (parser.header === expectedHeader) and (parser.usage === expectedUsage)
   }
 
-  def helpParserCompact(args: String*) = {
+  def helpParserTwoColumns(args: String*) = {
     case class Config(foo: Int = -1, out: File = new File("."), xyz: Boolean = false,
       libName: String = "", maxCount: Int = -1, verbose: Boolean = false, debug: Boolean = false,
       mode: String = "", files: Seq[File] = Seq(), keepalive: Boolean = false,
       jars: Seq[File] = Seq(), kwargs: Map[String,String] = Map())
     val parser = new scopt.OptionParser[Config]("scopt") {
-      override def showTwoColumnUsage = true
       head("scopt", "3.x")
       opt[Int]('f', "foo") action { (x, c) =>
         c.copy(foo = x) } text("foo is an integer property")
@@ -682,8 +682,7 @@ update is a command.
     printParserOut(_.showUsage()) === """scopt 3.x
 Usage: scopt [options]
 
-  --help
-        prints this usage text
+  --help  prints this usage text
 """
   }
 

--- a/src/test/scala/scopt/ImmutableParserSpec.scala
+++ b/src/test/scala/scopt/ImmutableParserSpec.scala
@@ -10,10 +10,10 @@ import scala.concurrent.duration.Duration
 import scala.util.Try
 class ImmutableParserSpec extends Specification { def is = args(sequential = true) ^ s2"""
   This is a specification to check the immutable parser
-  
+
   opt[Unit]('f', "foo") action { x => x } should
     parse () out of --foo                                       ${unitParser("--foo")}
-    parse () out of -f                                          ${unitParser("-f")} 
+    parse () out of -f                                          ${unitParser("-f")}
 
   opt[Unit]('a', "alice"); opt[Unit]('b', "bob"); opt[Unit]("alicebob") abbr("ab") action { x => x } should
     parse () out of -ab                                         ${groupParser("-ab")}
@@ -146,6 +146,9 @@ class ImmutableParserSpec extends Specification { def is = args(sequential = tru
 
   help("help") should
     print usage text --help                                     ${helpParser()}
+
+  help("help") if compact should
+    print usage text --help                                     ${helpParserCompact()}
 
   reportError("foo") should
     print "Error: foo\n"                                        ${reportErrorParser("foo")}
@@ -466,7 +469,7 @@ class ImmutableParserSpec extends Specification { def is = args(sequential = tru
 
   val cmdPosParser1 = new scopt.OptionParser[Config]("scopt") {
     head("scopt", "3.x")
-    arg[String]("<a>") action { (x, c) => c.copy(a = x) } 
+    arg[String]("<a>") action { (x, c) => c.copy(a = x) }
     cmd("update") action { (x, c) => c.copy(flag = true) } children(
       arg[String]("<b>") action { (x, c) => c.copy(b = x) },
       arg[String]("<c>")
@@ -480,7 +483,7 @@ class ImmutableParserSpec extends Specification { def is = args(sequential = tru
   }
   def cmdPosParserFail(args: String*) = {
     val result = cmdPosParser1.parse(args.toSeq, Config())
-    result === None    
+    result === None
   }
 
   val nestedCmdParser1 = new scopt.OptionParser[Config]("scopt") {
@@ -500,7 +503,7 @@ class ImmutableParserSpec extends Specification { def is = args(sequential = tru
   }
   def nestedCmdParserFail(args: String*) = {
     val result = nestedCmdParser1.parse(args.toSeq, Config())
-    result === None    
+    result === None
   }
 
   def helpParser(args: String*) = {
@@ -516,7 +519,7 @@ class ImmutableParserSpec extends Specification { def is = args(sequential = tru
         c.copy(out = x) } text("out is a required file property")
       opt[(String, Int)]("max") action { case ((k, v), c) =>
         c.copy(libName = k, maxCount = v) } validate { x =>
-        if (x._2 > 0) success else failure("Value <max> must be >0") 
+        if (x._2 > 0) success else failure("Value <max> must be >0")
       } keyValueName("<libname>", "<max>") text("maximum count for <libname>")
       opt[Seq[File]]('j', "jars") valueName("<jar1>,<jar2>...") action { (x,c) =>
          c.copy(jars = x) } text("jars to include")
@@ -570,6 +573,70 @@ update is a command.
         disable keepalive
   --xyz <value>
         xyz is a boolean property""".newlines
+    val expectedHeader = """scopt 3.x"""
+
+    (parser.header === expectedHeader) and (parser.usage === expectedUsage)
+  }
+
+  def helpParserCompact(args: String*) = {
+    case class Config(foo: Int = -1, out: File = new File("."), xyz: Boolean = false,
+      libName: String = "", maxCount: Int = -1, verbose: Boolean = false, debug: Boolean = false,
+      mode: String = "", files: Seq[File] = Seq(), keepalive: Boolean = false,
+      jars: Seq[File] = Seq(), kwargs: Map[String,String] = Map())
+    val parser = new scopt.OptionParser[Config]("scopt") {
+      override def showCompactUsage = true
+      head("scopt", "3.x")
+      opt[Int]('f', "foo") action { (x, c) =>
+        c.copy(foo = x) } text("foo is an integer property")
+      opt[File]('o', "out") required() valueName("<file>") action { (x, c) =>
+        c.copy(out = x) } text("out is a required file property")
+      opt[(String, Int)]("max") action { case ((k, v), c) =>
+        c.copy(libName = k, maxCount = v) } validate { x =>
+        if (x._2 > 0) success else failure("Value <max> must be >0")
+      } keyValueName("<libname>", "<max>") text("maximum count for <libname>")
+      opt[Seq[File]]('j', "jars") valueName("<jar1>,<jar2>...") action { (x,c) =>
+         c.copy(jars = x) } text("jars to include")
+      opt[Map[String,String]]("kwargs") valueName("k1=v1,k2=v2...") action { (x, c) =>
+        c.copy(kwargs = x) } text("other arguments")
+      opt[Unit]("verbose") action { (_, c) =>
+        c.copy(verbose = true) } text("verbose is a flag")
+      opt[Unit]("debug") hidden() action { (_, c) =>
+        c.copy(debug = true) } text("this option is hidden in the usage text")
+      help("help") text("prints this usage text")
+      arg[File]("<file>...") unbounded() optional() action { (x, c) =>
+        c.copy(files = c.files :+ x) } text("optional unbounded args")
+      note("some notes.".newline)
+      cmd("update") action { (_, c) =>
+        c.copy(mode = "update") } text("update is a command.") children(
+        opt[Unit]("not-keepalive") abbr("nk") action { (_, c) =>
+          c.copy(keepalive = false) } text("disable keepalive"),
+        opt[Boolean]("xyz") action { (x, c) =>
+          c.copy(xyz = x) } text("xyz is a boolean property"),
+        opt[Unit]("debug-update") hidden() action { (_, c) =>
+          c.copy(debug = true) } text("this option is hidden in the usage text"),
+        checkConfig { c =>
+          if (c.keepalive && c.xyz) failure("xyz cannot keep alive") else success }
+      )
+    }
+    parser.parse(args.toSeq, Config())
+    val expectedUsage= """scopt 3.x
+Usage: scopt [update] [options] [<file>...]
+
+  -f, --foo <value>         foo is an integer property
+  -o, --out <file>          out is a required file property
+  --max:<libname>=<max>     maximum count for <libname>
+  -j, --jars <jar1>,<jar2>...
+                            jars to include
+  --kwargs k1=v1,k2=v2...   other arguments
+  --verbose                 verbose is a flag
+  --help                    prints this usage text
+  <file>...                 optional unbounded args
+some notes.
+
+Command: update [options]
+update is a command.
+  -nk, --not-keepalive      disable keepalive
+  --xyz <value>             xyz is a boolean property""".newlines
     val expectedHeader = """scopt 3.x"""
 
     (parser.header === expectedHeader) and (parser.usage === expectedUsage)

--- a/src/test/scala/scopt/MutableParserSpec.scala
+++ b/src/test/scala/scopt/MutableParserSpec.scala
@@ -379,7 +379,7 @@ update is a command.
       mode: String = "", files: Seq[File] = Seq(), keepalive: Boolean = false)
     var c = Config()
     val parser = new scopt.OptionParser[Unit]("scopt") {
-      override def showCompactUsage = true
+      override def showTwoColumnUsage = true
       head("scopt", "3.x")
       opt[Int]('f', "foo") foreach { x =>
         c = c.copy(foo = x) } text("foo is an integer property")
@@ -411,18 +411,18 @@ update is a command.
     parser.usage === """scopt 3.x
 Usage: scopt [update] [options] [<file>...]
 
-  -f, --foo <value>         foo is an integer property
-  -o, --out <file>          out is a required file property
-  --max:<libname>=<max>     maximum count for <libname>
-  --verbose                 verbose is a flag
-  --help                    prints this usage text
-  <file>...                 optional unbounded args
+  -f, --foo <value>        foo is an integer property
+  -o, --out <file>         out is a required file property
+  --max:<libname>=<max>    maximum count for <libname>
+  --verbose                verbose is a flag
+  --help                   prints this usage text
+  <file>...                optional unbounded args
 some notes.
 
 Command: update [options]
 update is a command.
-  -nk, --not-keepalive      disable keepalive
-  --xyz <value>             xyz is a boolean property"""
+  -nk, --not-keepalive     disable keepalive
+  --xyz <value>            xyz is a boolean property"""
   }
 
   def printParserError(body: scopt.OptionParser[Unit] => Unit): String = {

--- a/src/test/scala/scopt/MutableParserSpec.scala
+++ b/src/test/scala/scopt/MutableParserSpec.scala
@@ -76,11 +76,11 @@ class MutableParserSpec extends Specification { def is = args(sequential = true)
   cmd("update") foreach { x => x } should
     parse () out of update                                      ${cmdParser("update")}
 
-  help("help") should
-    print usage text --help                                     ${helpParser()}
+  help("help") if OneColumn should
+    print usage text --help                                     ${helpParserOneColumn()}
 
-  help("help") if compact should
-    print usage text --help                                     ${helpParserCompact()}
+  help("help") if TwoColumn should
+    print usage text --help                                     ${helpParserTwoColumns()}
 
   reportError("foo") should
     print "Error: foo\n"                                        ${reportErrorParser("foo")}
@@ -314,12 +314,13 @@ class MutableParserSpec extends Specification { def is = args(sequential = true)
     (result === true) and (foo === true)
   }
 
-  def helpParser(args: String*) = {
+  def helpParserOneColumn(args: String*) = {
     case class Config(foo: Int = -1, out: File = new File("."), xyz: Boolean = false,
       libName: String = "", maxCount: Int = -1, verbose: Boolean = false, debug: Boolean = false,
       mode: String = "", files: Seq[File] = Seq(), keepalive: Boolean = false)
     var c = Config()
     val parser = new scopt.OptionParser[Unit]("scopt") {
+      override def renderingMode = scopt.RenderingMode.OneColumn
       head("scopt", "3.x")
       opt[Int]('f', "foo") foreach { x =>
         c = c.copy(foo = x) } text("foo is an integer property")
@@ -373,13 +374,12 @@ update is a command.
         xyz is a boolean property"""
   }
 
-  def helpParserCompact(args: String*) = {
+  def helpParserTwoColumns(args: String*) = {
     case class Config(foo: Int = -1, out: File = new File("."), xyz: Boolean = false,
       libName: String = "", maxCount: Int = -1, verbose: Boolean = false, debug: Boolean = false,
       mode: String = "", files: Seq[File] = Seq(), keepalive: Boolean = false)
     var c = Config()
     val parser = new scopt.OptionParser[Unit]("scopt") {
-      override def showTwoColumnUsage = true
       head("scopt", "3.x")
       opt[Int]('f', "foo") foreach { x =>
         c = c.copy(foo = x) } text("foo is an integer property")
@@ -456,8 +456,7 @@ update is a command.
     printParserOut(_.showUsage) === """scopt 3.x
 Usage: scopt [options]
 
-  --help
-        prints this usage text
+  --help  prints this usage text
 """
   }
 }

--- a/src/test/scala/scopt/MutableParserSpec.scala
+++ b/src/test/scala/scopt/MutableParserSpec.scala
@@ -414,9 +414,6 @@ Usage: scopt [update] [options] [<file>...]
   -f, --foo <value>         foo is an integer property
   -o, --out <file>          out is a required file property
   --max:<libname>=<max>     maximum count for <libname>
-  -j, --jars <jar1>,<jar2>...
-                            jars to include
-  --kwargs k1=v1,k2=v2...   other arguments
   --verbose                 verbose is a flag
   --help                    prints this usage text
   <file>...                 optional unbounded args


### PR DESCRIPTION
I've added the option for a more compact usage text that looks a bit more like many other outputs, like git, xsel, etc. The output is shown below.
It is enabled by using the following in you parser config:
`override def showCompactUsage = true`

Please let me know if I need to change anything to meet your approval.
Thanks!

```
scopt 3.x
Usage: scopt [update] [options] [<file>...]

  -f, --foo <value>         foo is an integer property
  -o, --out <file>          out is a required file property
  --max:<libname>=<max>     maximum count for <libname>
  -j, --jars <jar1>,<jar2>...
                            jars to include
  --kwargs k1=v1,k2=v2...   other arguments
  --verbose                 verbose is a flag
  --help                    prints this usage text
  <file>...                 optional unbounded args
some notes.

Command: update [options]
update is a command.
  -nk, --not-keepalive      disable keepalive
  --xyz <value>             xyz is a boolean property
```
