### PR TITLE
add support for base notation literals and implement hex notation

### DIFF
--- a/src/main/scala/scopt/options.scala
+++ b/src/main/scala/scopt/options.scala
@@ -25,7 +25,6 @@ object Read {
     val arity = 1
     val reads = f
   }
-  implicit val intRead: Read[Int]             = reads { _.toInt }
   implicit val stringRead: Read[String]       = reads { identity }
   implicit val doubleRead: Read[Double]       = reads { _.toDouble }
   implicit val booleanRead: Read[Boolean]     =
@@ -39,8 +38,24 @@ object Read {
       case s       =>
         throw new IllegalArgumentException("'" + s + "' is not a boolean.")
     }}
-  implicit val longRead: Read[Long]           = reads { _.toLong }
-  implicit val bigIntRead: Read[BigInt]       = reads { BigInt(_) }
+
+  private def fixedPointWithRadix(str: String): (String, Int) = str.toLowerCase match {
+    case s if s.startsWith("0x") => (s.stripPrefix("0x"), 16)
+    case s                       => (s, 10)
+  }
+  implicit val intRead: Read[Int] = reads { str =>
+    val (s, radix) = fixedPointWithRadix(str)
+    Integer.parseInt(s, radix)
+  }
+  implicit val longRead: Read[Long] = reads { str =>
+    val (s, radix) = fixedPointWithRadix(str)
+    java.lang.Long.parseLong(s, radix)
+  }
+  implicit val bigIntRead: Read[BigInt] = reads { str =>
+    val (s, radix) = fixedPointWithRadix(str)
+    BigInt(s, radix)
+  }
+
   implicit val bigDecimalRead: Read[BigDecimal] = reads { BigDecimal(_) }
   implicit val yyyymmdddRead: Read[Calendar] = calendarRead("yyyy-MM-dd")
   def calendarRead(pattern: String): Read[Calendar] = calendarRead(pattern, Locale.getDefault)

--- a/src/test/scala/scopt/ImmutableParserSpec.scala
+++ b/src/test/scala/scopt/ImmutableParserSpec.scala
@@ -26,9 +26,27 @@ class ImmutableParserSpec extends Specification { def is = args(sequential = tru
     parse 1 out of -f 1                                         ${intParser("-f", "1")}
     parse 1 out of -f:1                                         ${intParser("-f:1")}
     parse 1 out of -f=1                                         ${intParser("-f=1")}
+    parse 1 out of --foo 0x01                                   ${intParser("--foo", "0x01")}
+    parse 1 out of --foo:0x01                                   ${intParser("--foo:0x01")}
+    parse 1 out of --foo=0x01                                   ${intParser("--foo=0x01")}
+    parse 1 out of -f 0x1                                       ${intParser("-f", "0x1")}
+    parse 1 out of -f:0x1                                       ${intParser("-f:0x1")}
     fail to parse --foo                                         ${intParserFail{"--foo"}}
     fail to parse --foo bar                                     ${intParserFail("--foo", "bar")}
     fail to parse --foo=bar                                     ${intParserFail("--foo=bar")}
+
+  opt[Long]('f', "foo") action { x => x } should
+    parse 1 out of --foo 1                                      ${longParser("--foo", "1")}
+    parse 1 out of --foo:1                                      ${longParser("--foo:1")}
+    parse 1 out of --foo=1                                      ${longParser("--foo=1")}
+    parse 1 out of -f 1                                         ${longParser("-f", "1")}
+    parse 1 out of -f:1                                         ${longParser("-f:1")}
+    parse 1 out of -f=1                                         ${longParser("-f=1")}
+    parse 1 out of --foo 0x01                                   ${longParser("--foo", "0x01")}
+    parse 1 out of --foo:0x01                                   ${longParser("--foo:0x01")}
+    parse 1 out of --foo=0x01                                   ${longParser("--foo=0x01")}
+    parse 1 out of -f 0x1                                       ${longParser("-f", "0x1")}
+    parse 1 out of -f:0x1                                       ${longParser("-f:0x1")}
 
   opt[String]("foo") action { x => x } should
     parse "bar" out of --foo bar                                ${stringParser("--foo", "bar")}
@@ -209,6 +227,17 @@ class ImmutableParserSpec extends Specification { def is = args(sequential = tru
   def intParserFail(args: String*) = {
     val result = intParser1.parse(args.toSeq, Config())
     result === None
+  }
+
+  val longParser1 = new scopt.OptionParser[Config]("scopt") {
+    override def showUsageOnError = true
+    head("scopt", "3.x")
+    opt[Long]('f', "foo").action( (x, c) => c.copy(longValue = x))
+    help("help")
+  }
+  def longParser(args: String*) = {
+    val result = intParser1.parse(args.toSeq, Config())
+    result.get.intValue === 1
   }
 
   val stringParser1 = new scopt.OptionParser[Config]("scopt") {
@@ -733,7 +762,7 @@ Usage: scopt [options]
 """
   }
 
-  case class Config(flag: Boolean = false, intValue: Int = 0, stringValue: String = "",
+  case class Config(flag: Boolean = false, intValue: Int = 0, longValue: Long = 0L, stringValue: String = "",
     doubleValue: Double = 0.0, boolValue: Boolean = false, debug: Boolean = false,
     bigDecimalValue: BigDecimal = BigDecimal("0.0"),
     calendarValue: Calendar = new GregorianCalendar(1900, Calendar.JANUARY, 1),

--- a/src/test/scala/scopt/MutableParserSpec.scala
+++ b/src/test/scala/scopt/MutableParserSpec.scala
@@ -14,9 +14,26 @@ class MutableParserSpec extends Specification { def is = args(sequential = true)
     parse 1 out of --foo=1                                      ${intParser("--foo=1")}
     parse 1 out of -f 1                                         ${intParser("-f", "1")}
     parse 1 out of -f:1                                         ${intParser("-f:1")}
+    parse 1 out of --foo 0x01                                   ${intParser("--foo","0x01")}
+    parse 1 out of --foo:0x01                                   ${intParser("--foo:0x01")}
+    parse 1 out of --foo=0x01                                   ${intParser("--foo=0x01")}
+    parse 1 out of -f 0x1                                       ${intParser("-f", "0x1")}
+    parse 1 out of -f:0x1                                       ${intParser("-f:0x1")}
     fail to parse --foo                                         ${intParserFail{"--foo"}}
     fail to parse --foo bar                                     ${intParserFail("--foo", "bar")}
     fail to parse --foo=bar                                     ${intParserFail("--foo=bar")}
+
+  opt[Long]('f', "foo") foreach { x => x } should
+    parse 1 out of --foo 1                                      ${longParser("--foo", "1")}
+    parse 1 out of --foo:1                                      ${longParser("--foo:1")}
+    parse 1 out of --foo=1                                      ${longParser("--foo=1")}
+    parse 1 out of -f 1                                         ${longParser("-f", "1")}
+    parse 1 out of -f:1                                         ${longParser("-f:1")}
+    parse 1 out of --foo 0x01                                   ${longParser("--foo","0x01")}
+    parse 1 out of --foo:0x01                                   ${longParser("--foo:0x01")}
+    parse 1 out of --foo=0x01                                   ${longParser("--foo=0x01")}
+    parse 1 out of -f 0x1                                       ${longParser("-f", "0x1")}
+    parse 1 out of -f:0x1                                       ${longParser("-f:0x1")}
 
   opt[String]("foo") foreach { x => x } should
     parse "bar" out of --foo bar                                ${stringParser("--foo", "bar")}
@@ -128,6 +145,17 @@ class MutableParserSpec extends Specification { def is = args(sequential = true)
     }
     parser.parse(args.toSeq)
     foo === 1
+  }
+
+  def longParser(args: String*) = {
+    var foo = 0L
+    val parser = new scopt.OptionParser[Unit]("scopt") {
+      head("scopt", "3.x")
+      opt[Long]('f', "foo").foreach( x => foo = x )
+      help("help")
+    }
+    parser.parse(args.toSeq)
+    foo === 1L
   }
 
   def intParserFail(args: String*) = {


### PR DESCRIPTION
This adds ability to specify fixed point values using hexadecimal notation (e.g. `0xff`).

This makes sense because Scala allows hex literals directly, (e.g., `val myInt = 0xff`).
