### PR TITLE
Options descriptions accessible

### DIFF
--- a/shared/src/main/scala/scopt/options.scala
+++ b/shared/src/main/scala/scopt/options.scala
@@ -758,7 +758,6 @@ class OptionDef[A: Read, C](
       case Opt => "--" + name
       case _   => name
     }
-
     private[scopt] def argName: String =
     kind match {
       case Arg if getMinOccurs == 0 => "[" + fullName + "]"

--- a/shared/src/main/scala/scopt/options.scala
+++ b/shared/src/main/scala/scopt/options.scala
@@ -758,7 +758,7 @@ class OptionDef[A: Read, C](
       case Opt => "--" + name
       case _   => name
     }
-    private[scopt] def argName: String =
+  private[scopt] def argName: String =
     kind match {
       case Arg if getMinOccurs == 0 => "[" + fullName + "]"
       case _   => fullName

--- a/shared/src/main/scala/scopt/options.scala
+++ b/shared/src/main/scala/scopt/options.scala
@@ -646,15 +646,18 @@ class OptionDef[A: Read, C](
 
   private[scopt] val kind: OptionDefKind = _kind
   private[scopt] val id: Int = _id
-  private[scopt] val name: String = _name
+  val name: String = _name
   private[scopt] def callback: (A, C) => C = _action
-  private[scopt] def getMinOccurs: Int = _minOccurs
-  private[scopt] def getMaxOccurs: Int = _maxOccurs
+  def getMinOccurs: Int = _minOccurs
+  def getMaxOccurs: Int = _maxOccurs
   private[scopt] def shortOptOrBlank: String = _shortOpt getOrElse("")
   private[scopt] def hasParent: Boolean = _parentId.isDefined
   private[scopt] def getParentId: Option[Int] = _parentId
-  private[scopt] def isHidden: Boolean = _isHidden
+  def isHidden: Boolean = _isHidden
   private[scopt] def checks: Seq[C => Either[String, Unit]] = _configValidations
+  def desc: String = _desc
+  def shortOpt: Option[String] = _shortOpt
+  def valueName: Option[String] = _valueName
 
   private[scopt] def applyArgument(arg: String, config: C): Either[Seq[String], C] =
     try {
@@ -755,7 +758,8 @@ class OptionDef[A: Read, C](
       case Opt => "--" + name
       case _   => name
     }
-  private[scopt] def argName: String =
+
+    private[scopt] def argName: String =
     kind match {
       case Arg if getMinOccurs == 0 => "[" + fullName + "]"
       case _   => fullName


### PR DESCRIPTION
In our project, we want to test for each scopt.OptionParser whether the defined options have a description. Unfortunately the _desc is a private value in OptionDef and not available. 
We added some functions to make these value available, so they can be used in the unit testing of command line functions. We also plan to use this to autogenerate usage documentation in our project. This might be useful for other projects as well.