### PR TITLE
Doc change for captured output and OptionParser as a non-case abstract class

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,7 @@ Console.withOut(outCapture) {
     parser.parse(args, config)
   }
 }
-
-ParseResult(config, errCapture.toString, outCapture.toString)
+// Now stderr output from this block is in errCapture.toString, and stdout in outCapture.toString
 ```
 
 ### Rendering mode

--- a/README.md
+++ b/README.md
@@ -269,6 +269,23 @@ By default, when the `--help` or `--version` are invoked, they call `sys.exit(0)
 override def terminate(exitState: Either[String, Unit]): Unit = ()
 ```
 
+### Captured Output
+
+By default, scopt emits output when needed on stderr and stdout.  This is expected behavior when using scopt to process arguments for your stand-alone application.  However, if your application requires parsing arguments while not producing output directly, you may wish to capture stderr and stdout output rather than emit them directly.   Redirecting Console in Scala can accomplish this in a thread-safe way, within a scope of your chosing, like this:
+
+```scala
+val outCapture = new ByteArrayOutputStream
+val errCapture = new ByteArrayOutputStream
+
+Console.withOut(outCapture) {
+  Console.withErr(errCapture) {
+    parser.parse(args, config)
+  }
+}
+
+ParseResult(config, errCapture.toString, outCapture.toString)
+```
+
 ### Rendering mode
 
 scopt 3.5.0 introduced rendering mode, and adopted two-column rendeing of the usage text by default. To switch back to the older one-column rendering override the `renderingMode` method:

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ override def terminate(exitState: Either[String, Unit]): Unit = ()
 
 ### Captured Output
 
-By default, scopt emits output when needed on stderr and stdout.  This is expected behavior when using scopt to process arguments for your stand-alone application.  However, if your application requires parsing arguments while not producing output directly, you may wish to capture stderr and stdout output rather than emit them directly.   Redirecting Console in Scala can accomplish this in a thread-safe way, within a scope of your chosing, like this:
+By default, scopt emits output when needed to stderr and stdout.  This is expected behavior when using scopt to process arguments for your stand-alone application.  However, if your application requires parsing arguments while not producing output directly, you may wish to capture stderr and stdout output rather than emit them directly.   Redirecting Console in Scala can accomplish this in a thread-safe way, within a scope of your chosing, like this:
 
 ```scala
 val outCapture = new ByteArrayOutputStream

--- a/shared/src/main/scala/scopt/options.scala
+++ b/shared/src/main/scala/scopt/options.scala
@@ -217,7 +217,7 @@ private[scopt] case object Check extends OptionDefKind
  * }
  * }}}
  */
-abstract case class OptionParser[C](programName: String) {
+abstract class OptionParser[C](programName: String) {
   protected val options = new ListBuffer[OptionDef[_, C]]
   protected val helpOptions = new ListBuffer[OptionDef[_, C]]
 


### PR DESCRIPTION
This is the change discussed in the now-closed PR about captured output.  (The code base had shifted so making a new PR seemed cleaner.)   A small section shows how to capture stdout and stderr by redirecting Console.

One other small change is that I changed OptionParser from being a abstract case class to an abstract class (non-case).  This was to allow sub-classing of OptionParser, which is desirable.  If I have a lot of parsers, say for a set of commands, I don't want to rely on all the implementors of each command to override terminate().  All it takes is one careless developer and I've got a terminate() bomb in my system!  Much safer to sub-class.

Another benefit is that reportError and reportWarning can likewise be overridden in the subclass, for example if I wanted to support colorized output with something like jansi.

I noticed, at least in all the examples, the usage of this class shouldn't change at all for existing code.