### PR TITLE
add fallback to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Occurrence can be set using the methods on the opt/arg:
 
 ```scala
 opt[String]('o', "out").required()
+opt[String]('o', "out").required().withFallback(() => "default value")
 opt[String]('o', "out").minOccurs(1) // same as above
 arg[String]("<mode>").optional()
 arg[String]("<mode>").minOccurs(0) // same as above

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import com.typesafe.sbt.pgp.PgpKeys._
 // shadow sbt-scalajs' crossProject and CrossType until Scala.js 1.0.0 is released
 import sbtcrossproject.{crossProject, CrossType}
 
-def v: String = "3.6.0"
+def v: String = "3.6.1"
 
 lazy val root = project.in(file(".")).
   aggregate(scoptJS, scoptJVM, scoptNative).

--- a/jvm/src/test/scala/scopt/ImmutableParserSpec.scala
+++ b/jvm/src/test/scala/scopt/ImmutableParserSpec.scala
@@ -126,6 +126,10 @@ class ImmutableParserSpec extends Specification { def is = args(sequential = tru
   opt[String]("foo") required() action { x => x } should
     fail to parse Nil                                           ${requiredFail()}
 
+  opt[String]("foo").required().withFallback(() => "someFallback") should
+    parse provided value                                        ${requiredWithFallback(args = Seq("--stringValue", "provided"), expected = "provided")}
+    use fallback value                                          ${requiredWithFallback(args = Nil, expected = "someFallback")}
+
   opt[Unit]("debug") hidden() action { x => x } should
     parse () out of --debug                                     ${unitParserHidden("--debug")}
 
@@ -443,6 +447,13 @@ class ImmutableParserSpec extends Specification { def is = args(sequential = tru
     val result = requireParser1.parse(args.toSeq, Config())
     result === None
   }
+
+  def requiredWithFallback(args: Seq[String], expected: String) =
+    new scopt.OptionParser[Config]("scopt") {
+      head("scopt", "3.x")
+      opt[String]("stringValue").required().withFallback(() => "someFallback")
+        .action( (x, c) => c.copy(stringValue = x) )
+    }.parse(args, Config()) === Some(Config(stringValue = expected))
 
   val validParser1 = new scopt.OptionParser[Config]("scopt") {
     head("scopt", "3.x")

--- a/jvm/src/test/scala/scopt/MutableParserSpec.scala
+++ b/jvm/src/test/scala/scopt/MutableParserSpec.scala
@@ -69,6 +69,10 @@ class MutableParserSpec extends Specification { def is = args(sequential = true)
   opt[String]("foo") required() foreach { x => x } should
     fail to parse Nil                                           ${requiredFail()}
 
+  opt[String]("foo").required().withFallback(() => "someFallback") should
+    parse provided value                                        ${requiredWithFallback(args = Seq("--stringValue", "provided"), expected = "provided")}
+    use fallback value                                          ${requiredWithFallback(args = Nil, expected = "someFallback")}
+
   opt[Unit]("debug") hidden() foreach { x => x } should
     parse () out of --debug                                     ${unitParserHidden("--debug")}
 
@@ -258,6 +262,18 @@ class MutableParserSpec extends Specification { def is = args(sequential = true)
       help("help")
     }
     parser.parse(args.toSeq) === false
+  }
+
+  def requiredWithFallback(args: Seq[String], expected: String) = {
+    var stringValue = ""
+    val parser = new scopt.OptionParser[Unit]("scopt") {
+      head("scopt", "3.x")
+      opt[String]("stringValue").required().withFallback(() => "someFallback")
+        .foreach( x => stringValue = x )
+      help("help")
+    }
+    parser.parse(args) === true
+    stringValue === expected
   }
 
   def validFail(args: String*) = {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16-M1
+sbt.version=0.13.16


### PR DESCRIPTION
fixes https://github.com/scopt/scopt/issues/89

I didn't bother testing with scala native, but I think it'll just work. 
