### PR TITLE
Update to the latest travis_setup.sh for Scala Native

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,6 @@ matrix:
     before_script:
     - sudo chmod +x /usr/local/bin/sbt
     before_install:
-    - curl https://raw.githubusercontent.com/scala-native/scala-native/21539aa97947f7/bin/travis_setup.sh | bash -x
+    - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x
     script:
     - sbt ++$TRAVIS_SCALA_VERSION nativeTest/run


### PR DESCRIPTION
[Recent PR](https://github.com/scala-native/scala-native/pull/1195) changed the location of the travis setup script within a Scala Native repo. This PR updates travis build to point to the new location.