### PR TITLE
doExit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import com.typesafe.sbt.pgp.PgpKeys._
 // shadow sbt-scalajs' crossProject and CrossType until Scala.js 1.0.0 is released
 import sbtcrossproject.{crossProject, CrossType}
 
-def v: String = "3.7.0"
+def v: String = "3.7.1-SNAPSHOT"
 
 lazy val root = project.in(file(".")).
   aggregate(scoptJS, scoptJVM, scoptNative).

--- a/js/src/main/scala/PlatformReadInstances.scala
+++ b/js/src/main/scala/PlatformReadInstances.scala
@@ -27,6 +27,7 @@ private[scopt] object platform {
   def applyArgumentExHandler[C](desc: String, arg: String): PartialFunction[Throwable, Either[Seq[String], C]] = {
     case e: NumberFormatException => Left(Seq(desc + " expects a number but was given '" + arg + "'"))
     case e: ParseException        => Left(Seq(desc + " expects a Scala duration but was given '" + arg + "'"))
+    case e: ScoptExitException    => throw e
     case e: Throwable             => Left(Seq(desc + " failed when given '" + arg + "'. " + e.getMessage))
   }
 }

--- a/jvm/src/main/scala/PlatformReadInstances.scala
+++ b/jvm/src/main/scala/PlatformReadInstances.scala
@@ -33,6 +33,7 @@ private[scopt] object platform {
       case e: NumberFormatException => Left(Seq(desc + " expects a number but was given '" + arg + "'"))
       case e: UnknownHostException  => Left(Seq(desc + " expects a host name or an IP address but was given '" + arg + "' which is invalid"))
       case e: ParseException        => Left(Seq(desc + " expects a Scala duration but was given '" + arg + "'"))
+      case e: ScoptExitException    => throw e
       case e: Throwable             => Left(Seq(desc + " failed when given '" + arg + "'. " + e.getMessage))
     }
 

--- a/native/src/main/scala/PlatformReadInstances.scala
+++ b/native/src/main/scala/PlatformReadInstances.scala
@@ -15,6 +15,7 @@ private[scopt] object platform {
 
   def applyArgumentExHandler[C](desc: String, arg: String): PartialFunction[Throwable, Either[Seq[String], C]] = {
       case e: NumberFormatException => Left(Seq(desc + " expects a number but was given '" + arg + "'"))
+      case e: ScoptExitException    => throw e
       case e: Throwable             => Left(Seq(desc + " failed when given '" + arg + "'. " + e.getMessage))
     }
 


### PR DESCRIPTION
For test purposes I override the termination handler to no-op:
`override def terminate(exitState: Either[String, Unit]): Unit = ()`
and try to use `--help` option
This gets somewhat ugly error message after help, like:
> program 0.1
> Usage: program [update] [options] [<file>...]
> ...
> **Error: Missing option --out**
> **Try --help for more information.**

Please consider throwing (and not catching) an exception instead of sys.exit call in terminate like Java port of docopt allows:
`new org.docopt.Docopt(USAGE).withExit(false)`