### PR TITLE
fix compile error with latest Scala 2.13.x

### DIFF
--- a/shared/src/main/scala/scopt/OptionParser.scala
+++ b/shared/src/main/scala/scopt/OptionParser.scala
@@ -109,7 +109,7 @@ abstract class OptionParser[C](programName: String) extends OptionDefCallback[C]
   /** adds an argument invoked by an option without `-` or `--`.
    * @param name name in the usage text
    */
-  def arg[A: Read](name: String): OptionDef[A, C] = makeDef(OptionDefKind.Arg, name) required ()
+  def arg[A: Read](name: String): OptionDef[A, C] = makeDef(OptionDefKind.Arg, name).required()
 
   /** adds a command invoked by an option without `-` or `--`.
    * @param name name of the command


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/1731/consoleFull

```
[scopt] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.16/project-builds/scopt-0704e9aa57defccaa9021e4dc94c7dae26286ba4/shared/src/main/scala/scopt/options.scala:283:72: no arguments allowed for nullary method required: ()scopt.OptionDef[A,C]
[scopt] [error]   def arg[A: Read](name: String): OptionDef[A, C] = makeDef(Arg, name) required()
[scopt] [error]                                                                        ^
```