### PR TITLE
fix compile error with latest Scala 2.13.x

### DIFF
--- a/shared/src/main/scala/scopt/options.scala
+++ b/shared/src/main/scala/scopt/options.scala
@@ -280,7 +280,7 @@ abstract class OptionParser[C](programName: String) {
   /** adds an argument invoked by an option without `-` or `--`.
    * @param name name in the usage text
    */
-  def arg[A: Read](name: String): OptionDef[A, C] = makeDef(Arg, name) required()
+  def arg[A: Read](name: String): OptionDef[A, C] = makeDef(Arg, name).required()
 
   /** adds a command invoked by an option without `-` or `--`.
    * @param name name of the command


### PR DESCRIPTION
backport https://github.com/scopt/scopt/pull/238 to scopt3 branch because scala community build use `scopt3` branch