### PR TITLE
fixes #239 for scopt3

### DIFF
--- a/shared/src/main/scala/scopt/options.scala
+++ b/shared/src/main/scala/scopt/options.scala
@@ -521,9 +521,15 @@ abstract class OptionParser[C](programName: String) {
             i += option.tokensToRead(i, args) - 1
           } // if
         case None =>
+          def isShortOpt(arg: String): Boolean =
+            arg.startsWith("-") && (arg.length == 1 || ! {
+              val c = arg.charAt(1)
+              (c >= '0' && c <= '9') || c == '.'
+            })
+
           args(i) match {
             case arg if arg startsWith "--" => handleError("Unknown option " + arg)
-            case arg if arg startsWith "-"  =>
+            case arg if isShortOpt(arg) =>
               if (arg == "-") handleError("Unknown option " + arg)
               else handleShortOptions(arg drop 1)
             case arg if findCommand(arg).isDefined =>

--- a/shared/src/test/scala/scopt/ImmutableParserSpec.scala
+++ b/shared/src/test/scala/scopt/ImmutableParserSpec.scala
@@ -1,6 +1,7 @@
 import minitest._
 import java.io.ByteArrayOutputStream
 import java.net.URI
+
 import scala.concurrent.duration.Duration
 
 object ImmutableParserSpec extends SimpleTestSuite with PowerAssertions {

--- a/shared/src/test/scala/scopt/Issue239.scala
+++ b/shared/src/test/scala/scopt/Issue239.scala
@@ -1,0 +1,53 @@
+import minitest.SimpleTestSuite
+
+object Issue239 extends SimpleTestSuite with PowerAssertions {
+  test("double arg should accept negative numbers") {
+    val set = List("-3.1415926" -> -3.1415926, "-.1" -> -.1)
+    set.foreach { case (arg, expected) =>
+      val p = new scopt.OptionParser[Double]("Test") {
+        opt[String]('n', "name")
+        arg[Double]("value").action((v, _) => v)
+      }
+      val res = p.parse(Array(arg), Double.NaN)
+      assert(res == Some(expected))
+    }
+    ()
+  }
+
+  test("int arg should accept negative numbers") {
+    val set = List("-3" -> -3, "-0" -> 0)
+    set.foreach { case (arg, expected) =>
+      val p = new scopt.OptionParser[Int]("Test") {
+        opt[String]('n', "name")
+        arg[Int]("value").action((v, _) => v)
+      }
+      val res = p.parse(Array(arg), Int.MaxValue)
+      assert(res == Some(expected))
+    }
+    ()
+  }
+
+  test("double opt should accept negative numbers") {
+    val set = List("-3.1415926" -> -3.1415926, "-.1" -> -.1)
+    set.foreach { case (arg, expected) =>
+      val p = new scopt.OptionParser[Double]("Test") {
+        opt[Double]('v', "value").action((v, _) => v)
+      }
+      val res = p.parse(Array("-v", arg), Double.NaN)
+      assert(res == Some(expected))
+    }
+    ()
+  }
+
+  test("int opt should accept negative numbers") {
+    val set = List("-3" -> -3, "-0" -> 0)
+    set.foreach { case (arg, expected) =>
+      val p = new scopt.OptionParser[Int]("Test") {
+        opt[Int]('v', "value").action((v, _) => v)
+      }
+      val res = p.parse(Array("--value", arg), Int.MaxValue)
+      assert(res == Some(expected))
+    }
+    ()
+  }
+}


### PR DESCRIPTION
- when hyphen is followed by digit or period, assume it is a numeric
argument