### PR TITLE
Support default values for options

### DIFF
--- a/shared/src/test/scala/scopttest/ImmutableParserSpec.scala
+++ b/shared/src/test/scala/scopttest/ImmutableParserSpec.scala
@@ -160,6 +160,10 @@ object ImmutableParserSpec extends SimpleTestSuite with PowerAssertions {
     requiredWithFallback(args = Seq("--stringValue", "provided"), expected = "provided")
   }
 
+  test(".required().withDefault() should use the provided default value") {
+    requiredWithDefault(args = Seq("--stringValue"), default = "default", expected = "default")
+  }
+
   test(".required().withFallback() should use the fallback value") {
     requiredWithFallback(args = Nil, expected = "someFallback")
   }
@@ -536,6 +540,15 @@ Usage: scopt [options]
       opt[String]("stringValue")
         .required()
         .withFallback(() => "someFallback")
+        .action((x, c) => c.copy(stringValue = x))
+    }.parse(args, Config()) == Some(Config(stringValue = expected)))
+
+  def requiredWithDefault(args: Seq[String], default: String, expected: String): Unit =
+    assert(new scopt.OptionParser[Config]("scopt") {
+      head("scopt", "3.x")
+      opt[String]("stringValue")
+        .required()
+        .withDefault(default)
         .action((x, c) => c.copy(stringValue = x))
     }.parse(args, Config()) == Some(Config(stringValue = expected)))
 


### PR DESCRIPTION
Hi.

This is a proposal for a small feature which is seen among command line applications using GNU getopt. I wish to get early feedback whether this goes into the right direction.

What I would like to have is the ability to use an option as a flag and specify a special value at the same time; for instance:

`abc --color=if-tty` -- enables color if on TTY
`abc --color=none` -- disables color
`abc --color` -- enables color
`abc --color=always` -- same as above

Currently, there will be an error if an option has arity > 0, the parser expects to read another word after the option.

This should be printed in the help screen as

```
--color[=VALUE] ...
```