### PR TITLE
Indent multiline option descriptions

### DIFF
--- a/shared/src/main/scala/scopt/ORunner.scala
+++ b/shared/src/main/scala/scopt/ORunner.scala
@@ -48,7 +48,10 @@ private[scopt] object ORunner {
       sorted.toList
     }
 
-    def itemUsage(value: OptionDef[_, C]): String =
+    def itemUsage(value: OptionDef[_, C]): String = {
+
+      def indentDescription(desc: String): String = desc.split(NL).mkString(NLTB)
+
       value.kind match {
         case ProgramName         => value.desc
         case Head | Note | Check => value.desc
@@ -59,18 +62,19 @@ private[scopt] object ORunner {
           WW + (value.shortOpt map { o =>
             "-" + o + ":" + value.keyValueString + " | "
           } getOrElse { "" }) +
-            value.fullName + ":" + value.keyValueString + NLTB + value.desc
+            value.fullName + ":" + value.keyValueString + NLTB + indentDescription(value.desc)
         case Opt if value.read.arity == 1 =>
           WW + (value.shortOpt map { o =>
             "-" + o + " " + value.valueString + " | "
           } getOrElse { "" }) +
-            value.fullName + " " + value.valueString + NLTB + value.desc
+            value.fullName + " " + value.valueString + NLTB + indentDescription(value.desc)
         case Opt | OptHelp | OptVersion =>
           WW + (value.shortOpt map { o =>
             "-" + o + " | "
           } getOrElse { "" }) +
-            value.fullName + NLTB + value.desc
+            value.fullName + NLTB + indentDescription(value.desc)
       }
+    }
 
     lazy val header = (heads map { itemUsage }).mkString(NL)
 
@@ -104,7 +108,10 @@ private[scopt] object ORunner {
         else {
           if ((str.length + WW.length) <= col1Length)
             str + (" " * (col1Length - str.length)) + description
-          else str + NL + (" " * col1Length) + description
+              .split(NL)
+              .mkString(NL + " " * col1Length)
+          else
+            str + NL + description.split(NL).map(s => (" " * col1Length) + s).mkString(NL)
         }
       }
       value.kind match {

--- a/shared/src/test/scala/scopttest/MonadicParserSpec.scala
+++ b/shared/src/test/scala/scopttest/MonadicParserSpec.scala
@@ -517,6 +517,37 @@ object MonadicParserSpec extends SimpleTestSuite with PowerAssertions {
     ()
   }
 
+  test("showMultilineUsage") {
+    val builder = OParser.builder[Config]
+
+    val parser: OParser[_, Config] = {
+      import builder._
+      OParser.sequence(
+        programName("scopt"),
+        head("scopt", "4.x"),
+        help("help").text(
+          """|prints this usage text
+             |here's a second line of text""".stripMargin
+        )
+      )
+    }
+    val out = printParserOut {
+      OParser.parse(parser, List("--help"), Config(), new scopt.DefaultOParserSetup {
+        override def terminate(exitState: Either[String, Unit]): Unit = ()
+      })
+    }
+
+    assert(
+      out ==
+        """|scopt 4.x
+           |Usage: scopt [options]
+           |
+           |  --help  prints this usage text
+           |          here's a second line of text
+           |""".stripMargin)
+    ()
+  }
+
   case class Config(
       flag: Boolean = false,
       intValue: Int = 0,


### PR DESCRIPTION
Closes #196 

Adds support for multi-line help texts by indenting all lines, not just the first.