### PR TITLE
Support Scala Native 0.4.0-M2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+os: linux
 
 language: scala
 
@@ -9,9 +9,20 @@ jdk:
 matrix:
   include:
   - scala: 2.11.12
-    sudo: required
     before_script:
     - sudo chmod +x /usr/local/bin/sbt
+    env:
+    - SCALANATIVE_VERSION="0.3.9"
+    before_install:
+    - sudo apt-get update
+    - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x
+    script:
+    - sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M scoptNative/test
+  - scala: 2.11.12
+    before_script:
+    - sudo chmod +x /usr/local/bin/sbt
+    env:
+    - SCALANATIVE_VERSION="0.4.0-M2"
     before_install:
     - sudo apt-get update
     - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,7 @@
 val scalaJSVersion =
   Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.0")
+val scalaNativeVersion =
+  Option(System.getenv("SCALANATIVE_VERSION")).getOrElse("0.4.0-M2")
 
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
@@ -16,6 +18,6 @@ ivyXML :=
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.9")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % scalaNativeVersion)
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")


### PR DESCRIPTION
This PR adds Scala Native cross support in the scopt4 branch.
Is it possible to have a scopt release for 0.4.0-M2? It is the last dependency to ship sjsonnet for Scala Native, which is faster than both C and Go google implementations of the jsonnet language.
Thank you
Lorenzo