### PR TITLE
Fix withFallback when the Read instance isn't the inverse of toString scopt4

### DIFF
--- a/shared/src/main/scala/scopt/OptionDef.scala
+++ b/shared/src/main/scala/scopt/OptionDef.scala
@@ -213,6 +213,21 @@ class OptionDef[A: Read, C](
       }
     } catch applyArgumentExHandler(shortDescription.capitalize, arg)
 
+  private[scopt] def applyFallback(
+      x: A,
+      config: C,
+      onOption: Option[C => C]): Either[CSeq[String], C] =
+    try {
+      Validation.validateValue(_validations)(x) match {
+        case Right(_) =>
+          onOption match {
+            case Some(f) => Right(f(config))
+            case _       => Right(action(x, config))
+          }
+        case Left(xs) => Left(xs)
+      }
+    } catch applyArgumentExHandler(shortDescription.capitalize, x.toString)
+
   // number of tokens to read: 0 for no match, 2 for "--foo 1", 1 for "--foo:1"
   private[scopt] def shortOptTokens(arg: String): Int =
     _shortOpt match {

--- a/shared/src/test/scala/scopttest/ImmutableParserSpec.scala
+++ b/shared/src/test/scala/scopttest/ImmutableParserSpec.scala
@@ -299,6 +299,19 @@ Usage: scopt [options]
     noOptionTest()
   }
 
+  test("withFallback doesn't use .toString") {
+    val expectedValue: NotToStringInverse = NotToStringInverse("hi", 2)
+    val parser = new scopt.OptionParser[ConfigWithNotToStringInverse]("withFallback") {
+      head("withFallback")
+      opt[NotToStringInverse]('x', "x")
+        .withFallback(() => expectedValue)
+        .action { case (value, config) => config.copy(x = value) }
+    }
+
+    val parsed = parser.parse(Seq(), ConfigWithNotToStringInverse.empty)
+    assert(parsed.contains(ConfigWithNotToStringInverse(expectedValue)))
+  }
+
   val unitParser1 = new scopt.OptionParser[Config]("scopt") {
     head("scopt", "3.x")
     opt[Unit]('f', "foo").action((x, c) => c.copy(flag = true))

--- a/shared/src/test/scala/scopttest/MutableParserSpec.scala
+++ b/shared/src/test/scala/scopttest/MutableParserSpec.scala
@@ -136,6 +136,20 @@ object MutableParserSpec extends BasicTestSuite {
     showUsageParser()
   }
 
+  test("withFallback doesn't use .toString") {
+    val expectedConfig = NotToStringInverse("hi", 2)
+    var config = NotToStringInverse.empty
+    val parser = new scopt.OptionParser[Unit]("withFallback") {
+      head("withFallback")
+      opt[NotToStringInverse]('x', "x")
+        .withFallback(() => expectedConfig)
+        .foreach(value => config = value)
+    }
+
+    assert(parser.parse(Seq()))
+    assert(config == expectedConfig)
+  }
+
   import SpecUtil._
 
   def unitParser(args: String*): Unit = {

--- a/shared/src/test/scala/scopttest/NotToStringInverse.scala
+++ b/shared/src/test/scala/scopttest/NotToStringInverse.scala
@@ -1,0 +1,24 @@
+package scopttest
+
+/**
+ * The important thing about this config option is that `reads` not be able to parse the
+ * result of `NotToStringInverse#toString`.
+ */
+case class NotToStringInverse(s0: String, len: Int)
+
+object NotToStringInverse {
+  val empty: NotToStringInverse = NotToStringInverse("", 0)
+  implicit val reads: scopt.Read[NotToStringInverse] =
+    new scopt.Read[NotToStringInverse] {
+      override val arity: Int = 1
+
+      override val reads: String => NotToStringInverse =
+        (s: String) => (NotToStringInverse(s, s.length))
+    }
+}
+
+case class ConfigWithNotToStringInverse(x: NotToStringInverse)
+
+object ConfigWithNotToStringInverse {
+  val empty: ConfigWithNotToStringInverse = ConfigWithNotToStringInverse(NotToStringInverse.empty)
+}


### PR DESCRIPTION
This fixes #156 and #161 for scopt4.