### PR TITLE
Fix withFallback when the Read instance isn't the inverse of toString scopt3

### DIFF
--- a/shared/src/test/scala/scopt/ImmutableParserSpec.scala
+++ b/shared/src/test/scala/scopt/ImmutableParserSpec.scala
@@ -218,6 +218,19 @@ object ImmutableParserSpec extends BasicTestSuite {
     noOptionTest()
   }
 
+  test("withFallback doesn't use .toString") {
+    val expectedValue: NotToStringInverse = NotToStringInverse("hi", 2)
+    val parser = new scopt.OptionParser[ConfigWithNotToStringInverse]("withFallback") {
+      head("withFallback")
+      opt[NotToStringInverse]('x', "x")
+        .withFallback(() => expectedValue)
+        .action { case (value, config) => config.copy(x = value) }
+    }
+
+    val parsed = parser.parse(Seq(), ConfigWithNotToStringInverse.empty)
+    assert(parsed.contains(ConfigWithNotToStringInverse(expectedValue)))
+  }
+
   import SpecUtil._
 
   val unitParser1 = new scopt.OptionParser[Config]("scopt") {

--- a/shared/src/test/scala/scopt/MutableParserSpec.scala
+++ b/shared/src/test/scala/scopt/MutableParserSpec.scala
@@ -138,6 +138,20 @@ object MutableParserSpec extends BasicTestSuite {
     showUsageParser()
   }
 
+  test("withFallback doesn't use .toString") {
+    val expectedConfig = NotToStringInverse("hi", 2)
+    var config = NotToStringInverse.empty
+    val parser = new scopt.OptionParser[Unit]("withFallback") {
+      head("withFallback")
+      opt[NotToStringInverse]('x', "x")
+        .withFallback(() => expectedConfig)
+        .foreach(value => config = value)
+    }
+
+    assert(parser.parse(Seq()))
+    assert(config == expectedConfig)
+  }
+
   import SpecUtil._
 
   def unitParser(args: String*): Unit = {

--- a/shared/src/test/scala/scopt/NotToStringInverse.scala
+++ b/shared/src/test/scala/scopt/NotToStringInverse.scala
@@ -1,0 +1,22 @@
+/**
+ * The important thing about this config option is that `reads` not be able to parse the
+ * result of `NotToStringInverse#toString`.
+ */
+case class NotToStringInverse(s0: String, len: Int)
+
+object NotToStringInverse {
+  val empty: NotToStringInverse = NotToStringInverse("", 0)
+  implicit val reads: scopt.Read[NotToStringInverse] =
+    new scopt.Read[NotToStringInverse] {
+      override val arity: Int = 1
+
+      override val reads: String => NotToStringInverse =
+        (s: String) => (NotToStringInverse(s, s.length))
+    }
+}
+
+case class ConfigWithNotToStringInverse(x: NotToStringInverse)
+
+object ConfigWithNotToStringInverse {
+  val empty: ConfigWithNotToStringInverse = ConfigWithNotToStringInverse(NotToStringInverse.empty)
+}


### PR DESCRIPTION
This fixes #156 and #161 for scopt3.