### PR TITLE
Split side effects into OEffect

### DIFF
--- a/shared/src/main/scala/scopt/OEffect.scala
+++ b/shared/src/main/scala/scopt/OEffect.scala
@@ -1,0 +1,38 @@
+package scopt
+
+sealed trait OEffect
+object OEffect {
+  case class DisplayToOut(msg: String) extends OEffect
+  case class DisplayToErr(msg: String) extends OEffect
+  case class ReportError(msg: String) extends OEffect
+  case class ReportWarning(msg: String) extends OEffect
+  case class Terminate(exitState: Either[String, Unit]) extends OEffect
+}
+
+trait OEffectSetup {
+  def displayToOut(msg: String): Unit
+  def displayToErr(msg: String): Unit
+  def reportError(msg: String): Unit
+  def reportWarning(msg: String): Unit
+  def terminate(exitState: Either[String, Unit]): Unit
+}
+
+abstract class DefaultOEffectSetup extends OEffectSetup {
+  override def displayToOut(msg: String): Unit = {
+    Console.out.println(msg)
+  }
+  override def displayToErr(msg: String): Unit = {
+    Console.err.println(msg)
+  }
+  override def reportError(msg: String): Unit = {
+    displayToErr("Error: " + msg)
+  }
+  override def reportWarning(msg: String): Unit = {
+    displayToErr("Warning: " + msg)
+  }
+  override def terminate(exitState: Either[String, Unit]): Unit =
+    exitState match {
+      case Left(_)  => platform.exit(1)
+      case Right(_) => platform.exit(0)
+    }
+}

--- a/shared/src/main/scala/scopt/OParser.scala
+++ b/shared/src/main/scala/scopt/OParser.scala
@@ -179,14 +179,71 @@ object OParser {
         sequence(ps.head, ps.tail: _*)
       }
 
-  private[this] lazy val setup = new DefaultOParserSetup with OParserSetup {
+  private[this] lazy val psetup0 = new DefaultOParserSetup with OParserSetup {
+    def showUsageAsError(): Unit = ()
+    def showTryHelp(): Unit = ()
+  }
+  private[this] lazy val esetup0 = new DefaultOEffectSetup with OEffectSetup {
     def showUsageAsError(): Unit = ()
     def showTryHelp(): Unit = ()
   }
 
+  /** Run the parser, and run the effects.
+   */
   def parse[C](parser: OParser[_, C], args: CSeq[String], init: C): Option[C] =
-    ORunner.parse(args, init, parser.toList, setup)
+    ORunner.runParser(args, init, parser.toList, psetup0) match {
+      case (r, es) => ORunner.runEffects(es, esetup0); r
+    }
 
-  def parse[C](parser: OParser[_, C], args: CSeq[String], init: C, setup: OParserSetup): Option[C] =
-    ORunner.parse(args, init, parser.toList, setup)
+  /** Run the parser, and run the effects.
+   */
+  def parse[C](
+      parser: OParser[_, C],
+      args: CSeq[String],
+      init: C,
+      psetup: OParserSetup,
+      esetup: OEffectSetup): Option[C] =
+    ORunner.runParser(args, init, parser.toList, psetup) match {
+      case (r, es) => ORunner.runEffects(es, esetup); r
+    }
+
+  /** Run the parser, and run the effects.
+   */
+  def parse[C](
+      parser: OParser[_, C],
+      args: CSeq[String],
+      init: C,
+      psetup: OParserSetup): Option[C] =
+    ORunner.runParser(args, init, parser.toList, psetup) match {
+      case (r, es) => ORunner.runEffects(es, esetup0); r
+    }
+
+  /** Run the parser, and run the effects.
+   */
+  def parse[C](
+      parser: OParser[_, C],
+      args: CSeq[String],
+      init: C,
+      esetup: OEffectSetup): Option[C] =
+    ORunner.runParser(args, init, parser.toList, psetup0) match {
+      case (r, es) => ORunner.runEffects(es, esetup); r
+    }
+
+  /** Run the parser, and return the result and the effects.
+   */
+  def runParser[C](parser: OParser[_, C], args: CSeq[String], init: C): (Option[C], List[OEffect]) =
+    ORunner.runParser(args, init, parser.toList, psetup0)
+
+  /** Run the parser, and return the result and the effects.
+   */
+  def runParser[C](
+      parser: OParser[_, C],
+      args: CSeq[String],
+      init: C,
+      psetup: OParserSetup): (Option[C], List[OEffect]) =
+    ORunner.runParser(args, init, parser.toList, psetup)
+
+  def runEffects(es: List[OEffect]): Unit = ORunner.runEffects(es, esetup0)
+
+  def runEffects(es: List[OEffect], esetup: OEffectSetup): Unit = ORunner.runEffects(es, esetup)
 }

--- a/shared/src/main/scala/scopt/OParserSetup.scala
+++ b/shared/src/main/scala/scopt/OParserSetup.scala
@@ -10,32 +10,11 @@ trait OParserSetup {
    * --help option is not defined.
    */
   def showUsageOnError: Option[Boolean]
-  def displayToOut(msg: String): Unit
-  def displayToErr(msg: String): Unit
-  def reportError(msg: String): Unit
-  def reportWarning(msg: String): Unit
-  def terminate(exitState: Either[String, Unit]): Unit
+
 }
 
 abstract class DefaultOParserSetup extends OParserSetup {
   override def renderingMode: RenderingMode = RenderingMode.TwoColumns
   override def errorOnUnknownArgument: Boolean = true
   override def showUsageOnError: Option[Boolean] = None
-  override def displayToOut(msg: String): Unit = {
-    Console.out.println(msg)
-  }
-  override def displayToErr(msg: String): Unit = {
-    Console.err.println(msg)
-  }
-  override def reportError(msg: String): Unit = {
-    displayToErr("Error: " + msg)
-  }
-  override def reportWarning(msg: String): Unit = {
-    displayToErr("Warning: " + msg)
-  }
-  override def terminate(exitState: Either[String, Unit]): Unit =
-    exitState match {
-      case Left(_)  => platform.exit(1)
-      case Right(_) => platform.exit(0)
-    }
 }

--- a/shared/src/test/scala/scopttest/MonadicParserSpec.scala
+++ b/shared/src/test/scala/scopttest/MonadicParserSpec.scala
@@ -2,6 +2,7 @@ package scopttest
 
 import scala.concurrent.duration.Duration
 import scopt.OParser
+import scopt.OEffect._
 import SpecUtil._
 
 class MonadicParserSpec extends munit.FunSuite {
@@ -483,7 +484,7 @@ class MonadicParserSpec extends munit.FunSuite {
       )
     }
     val out = printParserOut {
-      OParser.parse(parser, List("--version"), Config(), new scopt.DefaultOParserSetup {
+      OParser.parse(parser, List("--version"), Config(), new scopt.DefaultOEffectSetup {
         override def terminate(exitState: Either[String, Unit]): Unit = ()
       })
     }
@@ -502,7 +503,7 @@ class MonadicParserSpec extends munit.FunSuite {
       )
     }
     val out = printParserOut {
-      OParser.parse(parser, List("--help"), Config(), new scopt.DefaultOParserSetup {
+      OParser.parse(parser, List("--help"), Config(), new scopt.DefaultOEffectSetup {
         override def terminate(exitState: Either[String, Unit]): Unit = ()
       })
     }
@@ -544,20 +545,19 @@ class MonadicParserSpec extends munit.FunSuite {
         )
       )
     }
-    val out = printParserOut {
-      OParser.parse(parser, List("--help"), Config(), new scopt.DefaultOParserSetup {
-        override def terminate(exitState: Either[String, Unit]): Unit = ()
-      })
-    }
+    val (_, effects) =
+      OParser.runParser(parser, List("--help"), Config())
 
-    assert(
-      out ==
+    assertEquals(
+      effects.head,
+      DisplayToOut(
         """|scopt 4.x
            |Usage: scopt [options]
            |
            |  --help  prints this usage text
-           |          here's a second line of text
-           |""".stripMargin)
+           |          here's a second line of text""".stripMargin
+      )
+    )
     ()
   }
 


### PR DESCRIPTION
By default, scopt emits output when needed to stderr and stdout.  This is expected behavior when using scopt to process arguments for your stand-alone application.  However, if your application requires parsing arguments while not producing output directly, you may wish to intercept the side effects.
Use `OParser.runParser(...)` to do so:

```scala
// OParser.runParser returns (Option[Config], List[OEffect])
OParser.runParser(parser1, args, Config()) match {
  case (result, effects) =>
    OParser.runEffects(effects, new DefaultOEffectSetup {
      // ignore terminate
      override def terminate(exitState: Either[String, Unit]): Unit = ()
    })
    result match {
      Some(config) =>
        // do something
      case _ =>
        // arguments are bad, error message will have been displayed
    }
}
```