### PR TITLE
[Proposal] Prepend Optional to the opt text

### DIFF
--- a/jvm/src/test/scala/scopt/MonadicParserSpecJVM.scala
+++ b/jvm/src/test/scala/scopt/MonadicParserSpecJVM.scala
@@ -15,21 +15,21 @@ object MonadicParserSpecJVM extends verify.BasicTestSuite {
     val expectedUsage = """scopt 4.x
 Usage: scopt [update] [options] [<file>...]
 
-  -f, --foo <value>        foo is an integer property
+  -f, --foo <value>        [Optional] foo is an integer property
   -o, --out <file>         out is a required file property
-  --max:<libname>=<max>    maximum count for <libname>
+  --max:<libname>=<max>    [Optional] maximum count for <libname>
   -j, --jars <jar1>,<jar2>...
-                           jars to include
-  --kwargs k1=v1,k2=v2...  other arguments
-  --verbose                verbose is a flag
+                           [Optional] jars to include
+  --kwargs k1=v1,k2=v2...  [Optional] other arguments
+  --verbose                [Optional] verbose is a flag
   --help                   prints this usage text
   <file>...                optional unbounded args
 some notes.
 
 Command: update [options]
 update is a command.
-  -nk, --not-keepalive     disable keepalive
-  --xyz <value>            xyz is a boolean property"""
+  -nk, --not-keepalive     [Optional] disable keepalive
+  --xyz <value>            [Optional] xyz is a boolean property"""
     assert(OParser.usage(parser1) == expectedUsage)
     ()
   }

--- a/shared/src/main/scala/scopt/OptionDef.scala
+++ b/shared/src/main/scala/scopt/OptionDef.scala
@@ -192,7 +192,13 @@ class OptionDef[A: Read, C](
   def hasFallback: Boolean = _fallback.isDefined
   def getFallback: A = _fallback.get.apply
   private[scopt] def checks: CSeq[C => Either[String, Unit]] = _configValidations
-  def desc: String = _desc
+  def desc: String = {
+    val isOptional = (_kind == Opt && _minOccurs == 0)
+    val prefix = if (isOptional) { "[Optional]" } else { "" }
+    val separator = if (isOptional && _desc.nonEmpty) { " " } else { "" }
+    s"""$prefix$separator${_desc}"""
+  }
+
   def shortOpt: Option[String] = _shortOpt
   def valueName: Option[String] = _valueName
 

--- a/shared/src/test/scala/scopttest/ImmutableParserSpec.scala
+++ b/shared/src/test/scala/scopttest/ImmutableParserSpec.scala
@@ -769,13 +769,13 @@ Usage: scopt [options]
 Usage: scopt [update] [options]
 
   -f <value> | --foo <value>
-        foo is an integer property
+        [Optional] foo is an integer property
   --max:<libname>=<max>
-        maximum count for <libname>
+        [Optional] maximum count for <libname>
   --kwargs k1=v1,k2=v2...
-        other arguments
+        [Optional] other arguments
   --verbose
-        verbose is a flag
+        [Optional] verbose is a flag
   --help
         prints this usage text
 some notes.
@@ -783,9 +783,9 @@ some notes.
 Command: update [options]
 update is a command.
   -nk | --not-keepalive
-        disable keepalive
+        [Optional] disable keepalive
   --xyz <value>
-        xyz is a boolean property""".newlines
+        [Optional] xyz is a boolean property""".newlines
     val expectedHeader = """scopt 3.x"""
 
     assert(parser.header == expectedHeader)
@@ -857,17 +857,17 @@ update is a command.
     val expectedUsage = """scopt 3.x
 Usage: scopt [update] [options]
 
-  -f, --foo <value>        foo is an integer property
-  --max:<libname>=<max>    maximum count for <libname>
-  --kwargs k1=v1,k2=v2...  other arguments
-  --verbose                verbose is a flag
+  -f, --foo <value>        [Optional] foo is an integer property
+  --max:<libname>=<max>    [Optional] maximum count for <libname>
+  --kwargs k1=v1,k2=v2...  [Optional] other arguments
+  --verbose                [Optional] verbose is a flag
   --help                   prints this usage text
 some notes.
 
 Command: update [options]
 update is a command.
-  -nk, --not-keepalive     disable keepalive
-  --xyz <value>            xyz is a boolean property""".newlines
+  -nk, --not-keepalive     [Optional] disable keepalive
+  --xyz <value>            [Optional] xyz is a boolean property""".newlines
     val expectedHeader = """scopt 3.x"""
 
     assert((parser.header == expectedHeader) && (parser.usage == expectedUsage))

--- a/shared/src/test/scala/scopttest/MonadicParserSpec.scala
+++ b/shared/src/test/scala/scopttest/MonadicParserSpec.scala
@@ -108,8 +108,8 @@ object MonadicParserSpec extends verify.BasicTestSuite {
         """scopt 4.x
         |Usage: scopt [options] <source> <dest>
         |
-        |  -f, --foo <value>  foo is an integer property
-        |  --debug            debug is a flag
+        |  -f, --foo <value>  [Optional] foo is an integer property
+        |  --debug            [Optional] debug is a flag
         |  <source>
         |  <dest>""".stripMargin)
     ()
@@ -180,8 +180,8 @@ object MonadicParserSpec extends verify.BasicTestSuite {
         """scopt 4.x
         |Usage: scopt [options]
         |
-        |  -b, --bob  text
-        |  -b, --bob""".stripMargin)
+        |  -b, --bob  [Optional] text
+        |  -b, --bob  [Optional]""".stripMargin)
     ()
   }
 
@@ -200,7 +200,7 @@ object MonadicParserSpec extends verify.BasicTestSuite {
         """scopt 4.x
         |Usage: scopt [options]
         |
-        |  -f, --foo""".stripMargin)
+        |  -f, --foo  [Optional]""".stripMargin)
     ()
   }
 
@@ -239,9 +239,9 @@ object MonadicParserSpec extends verify.BasicTestSuite {
         """scopt 4.x
         |Usage: scopt [options]
         |
-        |  -a, --alice
-        |  -b, --bob
-        |  -ab, --alicebob""".stripMargin)
+        |  -a, --alice      [Optional]
+        |  -b, --bob        [Optional]
+        |  -ab, --alicebob  [Optional]""".stripMargin)
     ()
   }
 
@@ -281,7 +281,7 @@ object MonadicParserSpec extends verify.BasicTestSuite {
         """scopt 4.x
         |Usage: scopt [options]
         |
-        |  -f, --foo <value>
+        |  -f, --foo <value>  [Optional]
         |  --help""".stripMargin)
     ()
   }
@@ -337,7 +337,7 @@ object MonadicParserSpec extends verify.BasicTestSuite {
         """scopt 4.x
         |Usage: scopt [options]
         |
-        |  -f, --foo <value>
+        |  -f, --foo <value>  [Optional]
         |  --help""".stripMargin)
     ()
   }
@@ -427,8 +427,8 @@ object MonadicParserSpec extends verify.BasicTestSuite {
         |
         |Command: update [options]
         |
-        |  --foo
-        |  --bar <value>""".stripMargin)
+        |  --foo                    [Optional]
+        |  --bar <value>            [Optional]""".stripMargin)
     ()
   }
 
@@ -462,13 +462,13 @@ object MonadicParserSpec extends verify.BasicTestSuite {
         |
         |Command: update [options]
         |
-        |  --foo
-        |  --bar <value>
+        |  --foo                    [Optional]
+        |  --bar <value>            [Optional]
         |
         |Command: status [options]
         |
-        |  --foo
-        |  --bar <value>
+        |  --foo                    [Optional]
+        |  --bar <value>            [Optional]
         |""".stripMargin)
     ()
   }

--- a/shared/src/test/scala/scopttest/MutableParserSpec.scala
+++ b/shared/src/test/scala/scopttest/MutableParserSpec.scala
@@ -459,11 +459,11 @@ object MutableParserSpec extends verify.BasicTestSuite {
 Usage: scopt [update] [options]
 
   -f <value> | --foo <value>
-        foo is an integer property
+        [Optional] foo is an integer property
   --max:<libname>=<max>
-        maximum count for <libname>
+        [Optional] maximum count for <libname>
   --verbose
-        verbose is a flag
+        [Optional] verbose is a flag
   --help
         prints this usage text
 some notes.
@@ -471,9 +471,9 @@ some notes.
 Command: update [options]
 update is a command.
   -nk | --not-keepalive
-        disable keepalive
+        [Optional] disable keepalive
   --xyz <value>
-        xyz is a boolean property""")
+        [Optional] xyz is a boolean property""")
   }
 
   def helpParserTwoColumns(args: String*): Unit = {
@@ -533,16 +533,16 @@ update is a command.
     assert(parser.usage == """scopt 3.x
 Usage: scopt [update] [options]
 
-  -f, --foo <value>        foo is an integer property
-  --max:<libname>=<max>    maximum count for <libname>
-  --verbose                verbose is a flag
+  -f, --foo <value>        [Optional] foo is an integer property
+  --max:<libname>=<max>    [Optional] maximum count for <libname>
+  --verbose                [Optional] verbose is a flag
   --help                   prints this usage text
 some notes.
 
 Command: update [options]
 update is a command.
-  -nk, --not-keepalive     disable keepalive
-  --xyz <value>            xyz is a boolean property""")
+  -nk, --not-keepalive     [Optional] disable keepalive
+  --xyz <value>            [Optional] xyz is a boolean property""")
   }
 
   def printParserError(body: scopt.OptionParser[Unit] => Unit): String = {


### PR DESCRIPTION
I would have a proposal to automatically prepend `Opt`s with `[Optional]` in help generation.

I find myself in the situation of having to add it by hand to each `text` in my projects and I think more people could benefit from this.

What do you think?
BTW omit it when there is no description as well?