### PR TITLE
Don't show 'Try help' when the help command is overwritten

### DIFF
--- a/shared/src/main/scala/scopt/ORunner.scala
+++ b/shared/src/main/scala/scopt/ORunner.scala
@@ -339,8 +339,10 @@ private[scopt] object ORunner {
         case a :: b :: Nil => a + " or " + b
         case _             => (xs.dropRight(2) :+ xs.takeRight(2).mkString(", or ")).mkString(", ")
       }
-      displayToErr(
-        "Try " + oxford(helpOptions.toList map { _.fullName }) + " for more information.")
+      if (helpOptions.nonEmpty) {
+        displayToErr(
+          "Try " + oxford(helpOptions.toList map { _.fullName }) + " for more information.")
+      }
     }
     while (i < args.length) {
       pendingOptions find { _.tokensToRead(i, args) > 0 } match {

--- a/shared/src/test/scala/scopttest/ImmutableParserSpec.scala
+++ b/shared/src/test/scala/scopttest/ImmutableParserSpec.scala
@@ -311,6 +311,37 @@ Usage: scopt [options]
     assert(parsed.contains(ConfigWithNotToStringInverse(expectedValue)))
   }
 
+  test("show 'Try --help'") {
+    val parser = new scopt.OptionParser[Config]("scopt") {
+      head("scopt", "3.x")
+      help("help").text("prints this usage text")
+      override def showUsageOnError: Option[Boolean] = Some(false)
+      override def terminate(exitState: Either[String, Unit]): Unit = ()
+    }
+    val err = printParserError {
+      parser.parse(List("--foo"), Config())
+    }
+    assert(err == """|Error: Unknown option --foo
+                     |Try --help for more information.
+                     |""".stripMargin)
+    ()
+  }
+
+  test("showTryHelp doesn't show 'Try --help' when the help command is not the kind of OptHelp") {
+    val parser = new scopt.OptionParser[Config]("scopt") {
+      head("scopt", "3.x")
+      opt[Unit]('h', "help").text("prints this usage text")
+      override def showUsageOnError: Option[Boolean] = Some(false)
+      override def terminate(exitState: Either[String, Unit]): Unit = ()
+    }
+    val err = printParserError {
+      parser.parse(List("--foo"), Config())
+    }
+    assert(err == """|Error: Unknown option --foo
+                     |""".stripMargin)
+    ()
+  }
+
   val unitParser1 = new scopt.OptionParser[Config]("scopt") {
     head("scopt", "3.x")
     opt[Unit]('f', "foo").action((x, c) => c.copy(flag = true))


### PR DESCRIPTION
When I was using scalafmt, I noticed a strange behavior.

```console
$ Error: Unknown option --foo
Try  for more information.
```
I expect that "Try ${some options} for more information" to be shown.

This happens because scalafmt has its own definition of the help command.

https://github.com/scalameta/scalafmt/blob/c8fb165952ed372a1293685bf488486265e057cd/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala#L61-L63

It may be a problem of scalafmt but I think that the scopt also needs to take care of the case where there is no `OptHelp` option.