### PR TITLE
Fixes scopt/scopt#312

### DIFF
--- a/shared/src/main/scala/scopt/ORunner.scala
+++ b/shared/src/main/scala/scopt/ORunner.scala
@@ -295,7 +295,14 @@ private[scopt] object ORunner {
       }
     }
     def handleOccurrence(opt: OptionDef[_, C], pending: ListBuffer[OptionDef[_, C]]): Unit = {
-      occurrences += (opt -> 1)
+
+      if (occurrences.contains(opt)) {
+        val o = occurrences(opt) + 1
+        occurrences += (opt -> o)
+      } else {
+        occurrences += (opt -> 1)
+      }
+
       if (occurrences(opt) >= opt.getMaxOccurs) {
         pending -= opt
       }

--- a/shared/src/test/scala/scopttest/Issue312.scala
+++ b/shared/src/test/scala/scopttest/Issue312.scala
@@ -1,0 +1,70 @@
+package scopttest
+
+import scopt.OptionParser
+
+case class Issue312Config(args: Seq[String])
+
+object Issue312 extends verify.BasicTestSuite /*munit.FunSuite*/ {
+  val parser = new OptionParser[Issue312Config]("test-args") {
+    arg[String]("[source_path...] <target_path>")
+      .minOccurs(2)
+      .unbounded()
+      .action((u, c) => c.copy(args = c.args :+ u))
+  }
+
+  val parserMore = new OptionParser[Issue312Config]("test-args") {
+    arg[String]("[source_path...] <target_path>")
+      .minOccurs(4)
+      .unbounded()
+      .action((u, c) => c.copy(args = c.args :+ u))
+  }
+
+  val parserNoMin = new OptionParser[Issue312Config]("test-args") {
+    arg[String]("[source_path...] <target_path>")
+      .unbounded()
+      .action((u, c) => c.copy(args = c.args :+ u))
+  }
+
+  test("minOccurs works correctly") {
+    val parsed = parser.parse(Array("1", "2"), Issue312Config(Seq.empty))
+
+    assert(parsed.contains(Issue312Config(Seq("1", "2"))))
+  }
+
+  test("larger setting works as expected") {
+    val data = Seq(1, 2, 3, 4, 5).map(_.toString)
+
+    val parsed = parserMore.parse(data, Issue312Config(Seq.empty))
+
+    assert(parsed.contains(Issue312Config(data)))
+  }
+
+  test("fails without enough args") {
+    val data = Seq(1).map(_.toString)
+
+    val parsed = parserMore.parse(data, Issue312Config(Seq.empty))
+
+    assert(parsed.isEmpty)
+  }
+
+  test("fails nearly enough args") {
+    val data = Seq(1, 2, 3).map(_.toString)
+
+    val parsed = parserMore.parse(data, Issue312Config(Seq.empty))
+
+    assert(parsed.isEmpty)
+  }
+
+  test("minOccurs change does not break default behaviour") {
+    val data = Seq(1).map(_.toString)
+    val bigData = Seq(1, 2, 3).map(_.toString)
+
+    val parsed = parserNoMin.parse(data, Issue312Config(Seq.empty))
+
+    assert(parsed.contains(Issue312Config(data)))
+
+    val parsedBig = parserNoMin.parse(bigData, Issue312Config(Seq.empty))
+
+    assert(parsedBig.contains(Issue312Config(bigData)))
+  }
+}


### PR DESCRIPTION
Thought I should have a go at fixing this. This now counts the number of arguments in the `occurences` map correctly, instead of always resetting them to 1. Fixes scopt/scopt#312 that I raised. I've also added a new test suite for `minOccurs` which tests this both fixes the bug and hopefully does not cause any regressions for parsers that don't have `minOccurs` defined.

Let me know if you need me to make any other changes!