### PR TITLE
avoid deprecated `java.net.URL` constructor

### DIFF
--- a/jvm/src/main/scala/PlatformReadInstances.scala
+++ b/jvm/src/main/scala/PlatformReadInstances.scala
@@ -31,7 +31,7 @@ private[scopt] object platform {
     implicit val pathRead: Read[Path] = Read.reads { Paths.get(_) }
     implicit val sourceRead: scopt.Read[Source] = scopt.Read.reads { Source.fromFile(_) }
     implicit val inetAddress: Read[InetAddress] = Read.reads { InetAddress.getByName(_) }
-    implicit val urlRead: Read[URL] = Read.reads { new URL(_) }
+    implicit val urlRead: Read[URL] = Read.reads { new URI(_).toURL }
   }
 
   def applyArgumentExHandler[C](

--- a/jvm/src/test/scala/scopt/ImmutableParserSpecJVM.scala
+++ b/jvm/src/test/scala/scopt/ImmutableParserSpecJVM.scala
@@ -8,7 +8,7 @@ import scala.io.Source
 
 object ImmutableParserSpecJVM extends verify.BasicTestSuite {
 
-  private val url = new URL("https://example.com")
+  private val url = new URI("https://example.com").toURL
   private val uri = new URI("https://example.com/robots.txt")
 
   test("calendar parser should parse 2000-01-01") {


### PR DESCRIPTION
- https://bugs.openjdk.org/browse/JDK-8295949
- https://github.com/openjdk/jdk/commit/4338f527aa81350e3636dcfbcd2eb17ddaad3914