### PR TITLE
remove `-source:3.0-migration`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val scopt = (crossProject(JSPlatform, JVMPlatform, NativePlatform) in file(
     scalacOptions ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((3, _)) =>
-          Seq("-source:3.0-migration")
+          Nil
         case Some((2, v)) if v <= 12 =>
           Seq("-Xfuture")
         case _ =>

--- a/shared/src/test/scala/scopttest/Issue239.scala
+++ b/shared/src/test/scala/scopttest/Issue239.scala
@@ -3,11 +3,11 @@ package scopttest
 object Issue239 extends verify.BasicTestSuite {
   test("double arg should accept negative numbers") {
     val set = List("-3.1415926" -> -3.1415926, "-.1" -> -.1)
+    val p = new scopt.OptionParser[Double]("Test") {
+      opt[String]('n', "name")
+      arg[Double]("value").action((v, _) => v)
+    }
     set.foreach { case (arg, expected) =>
-      val p = new scopt.OptionParser[Double]("Test") {
-        opt[String]('n', "name")
-        arg[Double]("value").action((v, _) => v)
-      }
       val res = p.parse(Array("--", arg), Double.NaN)
       assert(res == Some(expected))
     }
@@ -16,11 +16,11 @@ object Issue239 extends verify.BasicTestSuite {
 
   test("int arg should accept negative numbers") {
     val set = List("-3" -> -3, "-0" -> 0)
+    val p = new scopt.OptionParser[Int]("Test") {
+      opt[String]('n', "name")
+      arg[Int]("value").action((v, _) => v)
+    }
     set.foreach { case (arg, expected) =>
-      val p = new scopt.OptionParser[Int]("Test") {
-        opt[String]('n', "name")
-        arg[Int]("value").action((v, _) => v)
-      }
       val res = p.parse(Array("--", arg), Int.MaxValue)
       assert(res == Some(expected))
     }


### PR DESCRIPTION
avoid ambiguous reference

```
[warn] -- [E049] Reference Migration Warning: /home/runner/work/scopt/scopt/shared/src/test/scala/scopttest/Issue239.scala:9:8
[warn] 9 |        arg[Double]("value").action((v, _) => v)
[warn]   |        ^^^
[warn]   |Reference to arg is ambiguous,
[warn]   |it is both defined in method $anonfun
[warn]   |and inherited subsequently in anonymous class scopt.OptionParser[Double] {...}
[warn]   |
[warn]   | longer explanation available when compiling with `-explain`
[warn] -- [E049] Reference Migration Warning: /home/runner/work/scopt/scopt/shared/src/test/scala/scopttest/Issue239.scala:22:8
[warn] 22 |        arg[Int]("value").action((v, _) => v)
[warn]    |        ^^^
[warn]    |Reference to arg is ambiguous,
[warn]    |it is both defined in method $anonfun
[warn]    |and inherited subsequently in anonymous class scopt.OptionParser[Int] {...}
[warn]    |
[warn]    | longer explanation available when compiling with `-explain`
```